### PR TITLE
Simple SSE subscription implementation

### DIFF
--- a/src/main/java/graphql/servlet/DefaultExecutionStrategyProvider.java
+++ b/src/main/java/graphql/servlet/DefaultExecutionStrategyProvider.java
@@ -2,6 +2,7 @@ package graphql.servlet;
 
 import graphql.execution.AsyncExecutionStrategy;
 import graphql.execution.ExecutionStrategy;
+import graphql.execution.SubscriptionExecutionStrategy;
 
 /**
  * @author Andrew Potter
@@ -21,13 +22,9 @@ public class DefaultExecutionStrategyProvider implements ExecutionStrategyProvid
     }
 
     public DefaultExecutionStrategyProvider(ExecutionStrategy queryExecutionStrategy, ExecutionStrategy mutationExecutionStrategy, ExecutionStrategy subscriptionExecutionStrategy) {
-        this.queryExecutionStrategy = defaultIfNull(queryExecutionStrategy);
+        this.queryExecutionStrategy = defaultIfNull(queryExecutionStrategy, new AsyncExecutionStrategy());
         this.mutationExecutionStrategy = defaultIfNull(mutationExecutionStrategy, this.queryExecutionStrategy);
-        this.subscriptionExecutionStrategy = defaultIfNull(subscriptionExecutionStrategy, this.queryExecutionStrategy);
-    }
-
-    private ExecutionStrategy defaultIfNull(ExecutionStrategy executionStrategy) {
-        return defaultIfNull(executionStrategy, new AsyncExecutionStrategy());
+        this.subscriptionExecutionStrategy = defaultIfNull(subscriptionExecutionStrategy, new SubscriptionExecutionStrategy());
     }
 
     private ExecutionStrategy defaultIfNull(ExecutionStrategy executionStrategy, ExecutionStrategy defaultStrategy) {

--- a/src/main/java/graphql/servlet/GraphQLSchemaProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLSchemaProvider.java
@@ -7,7 +7,7 @@ import javax.servlet.http.HttpServletRequest;
 public interface GraphQLSchemaProvider {
 
     static GraphQLSchema copyReadOnly(GraphQLSchema schema) {
-        return GraphQLSchema.newSchema().query(schema.getQueryType()).build(schema.getAdditionalTypes());
+        return GraphQLSchema.newSchema().query(schema.getQueryType()).subscription(schema.getSubscriptionType()).build(schema.getAdditionalTypes());
     }
 
     /**

--- a/src/main/java/graphql/servlet/GraphQLSubscriptionProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLSubscriptionProvider.java
@@ -1,0 +1,9 @@
+package graphql.servlet;
+
+import graphql.schema.GraphQLFieldDefinition;
+
+import java.util.Collection;
+
+public interface GraphQLSubscriptionProvider extends GraphQLProvider {
+    Collection<GraphQLFieldDefinition> getSubscriptions();
+}


### PR DESCRIPTION
Hi,

I don't know if it can be useful since you're working on subscription rework, but I needed a simple SSE implementation of subscriptions on 4.7.0 and implemented this. I think some part can still be integrated :

- SSE support itself, handled in doQuery when ExecutionResult is a subscription result
- Default subscription strategy was not set
- readOnlySchema must include subscriptions ( I'm using SSE with GET requests )
- OSGi servlet register subscriptions with new "SubscriptionsProvider"
- OSGi servlet support async

Also needed to upgrade graphql-java because of https://github.com/graphql-java/graphql-java/issues/844 

Feel free to take anything from here or drop it ..

Regards
