### PR TITLE
Handle Apollo subscription onConnect

### DIFF
--- a/src/main/java/graphql/servlet/ApolloSubscriptionConnectionListener.java
+++ b/src/main/java/graphql/servlet/ApolloSubscriptionConnectionListener.java
@@ -7,7 +7,7 @@ public interface ApolloSubscriptionConnectionListener extends SubscriptionConnec
     String CONNECT_RESULT_KEY = "CONNECT_RESULT";
 
     default boolean isKeepAliveEnabled() {
-        return true;
+        return false;
     }
 
     default Optional<Object> onConnect(Object payload) {

--- a/src/main/java/graphql/servlet/ApolloSubscriptionConnectionListener.java
+++ b/src/main/java/graphql/servlet/ApolloSubscriptionConnectionListener.java
@@ -1,0 +1,17 @@
+package graphql.servlet;
+
+import java.util.Optional;
+
+public interface ApolloSubscriptionConnectionListener extends SubscriptionConnectionListener {
+
+    String CONNECT_RESULT_KEY = "CONNECT_RESULT";
+
+    default boolean isKeepAliveEnabled() {
+        return true;
+    }
+
+    default Optional<Object> onConnect(Object payload) {
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/graphql/servlet/DefaultGraphQLContextBuilder.java
+++ b/src/main/java/graphql/servlet/DefaultGraphQLContextBuilder.java
@@ -2,6 +2,7 @@ package graphql.servlet;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.websocket.Session;
 import javax.websocket.server.HandshakeRequest;
 
 public class DefaultGraphQLContextBuilder implements GraphQLContextBuilder {
@@ -12,8 +13,8 @@ public class DefaultGraphQLContextBuilder implements GraphQLContextBuilder {
     }
 
     @Override
-    public GraphQLContext build(HandshakeRequest handshakeRequest) {
-        return new GraphQLContext(handshakeRequest);
+    public GraphQLContext build(Session session, HandshakeRequest handshakeRequest) {
+        return new GraphQLContext(session, handshakeRequest);
     }
 
     @Override

--- a/src/main/java/graphql/servlet/GraphQLContext.java
+++ b/src/main/java/graphql/servlet/GraphQLContext.java
@@ -6,14 +6,17 @@ import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
+import javax.websocket.Session;
 import javax.websocket.server.HandshakeRequest;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 public class GraphQLContext {
+
     private HttpServletRequest httpServletRequest;
     private HttpServletResponse httpServletResponse;
+    private Session session;
     private HandshakeRequest handshakeRequest;
 
     private Subject subject;
@@ -21,9 +24,10 @@ public class GraphQLContext {
 
     private DataLoaderRegistry dataLoaderRegistry;
 
-    public GraphQLContext(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, HandshakeRequest handshakeRequest, Subject subject) {
+    public GraphQLContext(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Session session, HandshakeRequest handshakeRequest, Subject subject) {
         this.httpServletRequest = httpServletRequest;
         this.httpServletResponse = httpServletResponse;
+        this.session = session;
         this.handshakeRequest = handshakeRequest;
         this.subject = subject;
     }
@@ -33,25 +37,31 @@ public class GraphQLContext {
     }
 
     public GraphQLContext(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
-        this(httpServletRequest, httpServletResponse, null, null);
+        this(httpServletRequest, httpServletResponse, null, null, null);
     }
 
-    public GraphQLContext(HandshakeRequest handshakeRequest) {
-        this(null, null, handshakeRequest, null);
+    public GraphQLContext(Session session, HandshakeRequest handshakeRequest) {
+        this(null, null, session, handshakeRequest, null);
     }
 
     public GraphQLContext() {
-        this(null, null, null, null);
+        this(null, null, null, null, null);
     }
 
     public Optional<HttpServletRequest> getHttpServletRequest() {
         return Optional.ofNullable(httpServletRequest);
     }
 
-    public Optional<HttpServletResponse> getHttpServletResponse() { return Optional.ofNullable(httpServletResponse); }
+    public Optional<HttpServletResponse> getHttpServletResponse() {
+        return Optional.ofNullable(httpServletResponse);
+    }
 
     public Optional<Subject> getSubject() {
         return Optional.ofNullable(subject);
+    }
+
+    public Optional<Session> getSession() {
+        return Optional.ofNullable(session);
     }
 
     public Optional<HandshakeRequest> getHandshakeRequest() {

--- a/src/main/java/graphql/servlet/GraphQLContext.java
+++ b/src/main/java/graphql/servlet/GraphQLContext.java
@@ -64,6 +64,13 @@ public class GraphQLContext {
         return Optional.ofNullable(session);
     }
 
+    public Optional<Object> getConnectResult() {
+        if (session != null) {
+            return Optional.ofNullable(session.getUserProperties().get(ApolloSubscriptionConnectionListener.CONNECT_RESULT_KEY));
+        }
+        return Optional.empty();
+    }
+
     public Optional<HandshakeRequest> getHandshakeRequest() {
         return Optional.ofNullable(handshakeRequest);
     }

--- a/src/main/java/graphql/servlet/GraphQLContextBuilder.java
+++ b/src/main/java/graphql/servlet/GraphQLContextBuilder.java
@@ -2,13 +2,14 @@ package graphql.servlet;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.websocket.Session;
 import javax.websocket.server.HandshakeRequest;
 
 public interface GraphQLContextBuilder {
 
     GraphQLContext build(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse);
 
-    GraphQLContext build(HandshakeRequest handshakeRequest);
+    GraphQLContext build(Session session, HandshakeRequest handshakeRequest);
 
     /**
      * Only used for MBean calls.

--- a/src/main/java/graphql/servlet/GraphQLContextBuilder.java
+++ b/src/main/java/graphql/servlet/GraphQLContextBuilder.java
@@ -5,7 +5,9 @@ import javax.servlet.http.HttpServletResponse;
 import javax.websocket.server.HandshakeRequest;
 
 public interface GraphQLContextBuilder {
+
     GraphQLContext build(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse);
+
     GraphQLContext build(HandshakeRequest handshakeRequest);
 
     /**

--- a/src/main/java/graphql/servlet/GraphQLInvocationInputFactory.java
+++ b/src/main/java/graphql/servlet/GraphQLInvocationInputFactory.java
@@ -5,6 +5,7 @@ import graphql.servlet.internal.GraphQLRequest;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.websocket.Session;
 import javax.websocket.server.HandshakeRequest;
 import java.util.List;
 import java.util.function.Supplier;
@@ -70,20 +71,20 @@ public class GraphQLInvocationInputFactory {
         );
     }
 
-    public GraphQLSingleInvocationInput create(GraphQLRequest graphQLRequest, HandshakeRequest request) {
+    public GraphQLSingleInvocationInput create(GraphQLRequest graphQLRequest, Session session, HandshakeRequest request) {
         return new GraphQLSingleInvocationInput(
             graphQLRequest,
             schemaProviderSupplier.get().getSchema(request),
-            contextBuilderSupplier.get().build(request),
+            contextBuilderSupplier.get().build(session, request),
             rootObjectBuilderSupplier.get().build(request)
         );
     }
 
-    public GraphQLBatchedInvocationInput create(List<GraphQLRequest> graphQLRequest, HandshakeRequest request) {
+    public GraphQLBatchedInvocationInput create(List<GraphQLRequest> graphQLRequest, Session session, HandshakeRequest request) {
         return new GraphQLBatchedInvocationInput(
             graphQLRequest,
             schemaProviderSupplier.get().getSchema(request),
-            contextBuilderSupplier.get().build(request),
+            contextBuilderSupplier.get().build(session, request),
             rootObjectBuilderSupplier.get().build(request)
         );
     }

--- a/src/main/java/graphql/servlet/GraphQLWebsocketServlet.java
+++ b/src/main/java/graphql/servlet/GraphQLWebsocketServlet.java
@@ -10,7 +10,6 @@ import javax.websocket.server.ServerEndpointConfig;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -48,7 +47,11 @@ public class GraphQLWebsocketServlet extends Endpoint {
     private final Object cacheLock = new Object();
 
     public GraphQLWebsocketServlet(GraphQLQueryInvoker queryInvoker, GraphQLInvocationInputFactory invocationInputFactory, GraphQLObjectMapper graphQLObjectMapper) {
-        this.subscriptionHandlerInput = new SubscriptionHandlerInput(invocationInputFactory, queryInvoker, graphQLObjectMapper);
+        this(queryInvoker, invocationInputFactory, graphQLObjectMapper, null);
+    }
+
+    public GraphQLWebsocketServlet(GraphQLQueryInvoker queryInvoker, GraphQLInvocationInputFactory invocationInputFactory, GraphQLObjectMapper graphQLObjectMapper, SubscriptionConnectionListener subscriptionConnectionListener) {
+        this.subscriptionHandlerInput = new SubscriptionHandlerInput(invocationInputFactory, queryInvoker, graphQLObjectMapper, subscriptionConnectionListener);
     }
 
     @Override

--- a/src/main/java/graphql/servlet/SubscriptionConnectionListener.java
+++ b/src/main/java/graphql/servlet/SubscriptionConnectionListener.java
@@ -1,0 +1,7 @@
+package graphql.servlet;
+
+/**
+ * Marker interface
+ */
+public interface SubscriptionConnectionListener {
+}

--- a/src/main/java/graphql/servlet/internal/ApolloSubscriptionProtocolHandler.java
+++ b/src/main/java/graphql/servlet/internal/ApolloSubscriptionProtocolHandler.java
@@ -48,8 +48,8 @@ public class ApolloSubscriptionProtocolHandler extends SubscriptionProtocolHandl
 
         switch(message.getType()) {
             case GQL_CONNECTION_INIT:
-                sendMessage(session, OperationMessage.Type.GQL_CONNECTION_ACK, message.getId());
-                sendMessage(session, OperationMessage.Type.GQL_CONNECTION_KEEP_ALIVE, message.getId());
+                sendMessage(session, OperationMessage.Type.GQL_CONNECTION_ACK, message.getId(), message.getPayload());
+                sendMessage(session, OperationMessage.Type.GQL_CONNECTION_KEEP_ALIVE, message.getId(), message.getPayload());
                 break;
 
             case GQL_START:
@@ -58,7 +58,7 @@ public class ApolloSubscriptionProtocolHandler extends SubscriptionProtocolHandl
                     subscriptions,
                     message.id,
                     input.getQueryInvoker().query(input.getInvocationInputFactory().create(
-                        input.getGraphQLObjectMapper().getJacksonMapper().convertValue(message.payload, GraphQLRequest.class),
+                        input.getGraphQLObjectMapper().getJacksonMapper().convertValue(message.getPayload(), GraphQLRequest.class),
                         (HandshakeRequest) session.getUserProperties().get(HandshakeRequest.class.getName())
                     ))
                 );

--- a/src/main/java/graphql/servlet/internal/ApolloSubscriptionProtocolHandler.java
+++ b/src/main/java/graphql/servlet/internal/ApolloSubscriptionProtocolHandler.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonValue;
 import graphql.ExecutionResult;
+import graphql.servlet.ApolloSubscriptionConnectionListener;
+import graphql.servlet.GraphQLSingleInvocationInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +15,7 @@ import javax.websocket.server.HandshakeRequest;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static graphql.servlet.internal.ApolloSubscriptionProtocolHandler.OperationMessage.Type.GQL_COMPLETE;
 import static graphql.servlet.internal.ApolloSubscriptionProtocolHandler.OperationMessage.Type.GQL_CONNECTION_TERMINATE;
@@ -30,9 +33,14 @@ public class ApolloSubscriptionProtocolHandler extends SubscriptionProtocolHandl
     private static final CloseReason TERMINATE_CLOSE_REASON = new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "client requested " + GQL_CONNECTION_TERMINATE.getType());
 
     private final SubscriptionHandlerInput input;
+    private final ApolloSubscriptionConnectionListener connectionListener;
 
     public ApolloSubscriptionProtocolHandler(SubscriptionHandlerInput subscriptionHandlerInput) {
         this.input = subscriptionHandlerInput;
+        this.connectionListener = subscriptionHandlerInput.getSubscriptionConnectionListener()
+                .filter(ApolloSubscriptionConnectionListener.class::isInstance)
+                .map(ApolloSubscriptionConnectionListener.class::cast)
+                .orElse(new ApolloSubscriptionConnectionListener() {});
     }
 
     @Override
@@ -48,19 +56,22 @@ public class ApolloSubscriptionProtocolHandler extends SubscriptionProtocolHandl
 
         switch(message.getType()) {
             case GQL_CONNECTION_INIT:
-                sendMessage(session, OperationMessage.Type.GQL_CONNECTION_ACK, message.getId(), message.getPayload());
-                sendMessage(session, OperationMessage.Type.GQL_CONNECTION_KEEP_ALIVE, message.getId(), message.getPayload());
+                Optional<Object> connectionResponse = connectionListener.onConnect(message.getPayload());
+                connectionResponse.ifPresent(it -> session.getUserProperties().put(ApolloSubscriptionConnectionListener.CONNECT_RESULT_KEY, it));
+                sendMessage(session, OperationMessage.Type.GQL_CONNECTION_ACK, message.getId());
+
+                if (connectionListener.isKeepAliveEnabled()) {
+                    sendMessage(session, OperationMessage.Type.GQL_CONNECTION_KEEP_ALIVE, message.getId());
+                }
                 break;
 
             case GQL_START:
+                GraphQLSingleInvocationInput graphQLSingleInvocationInput = createInvocationInput(session, message);
                 handleSubscriptionStart(
                     session,
                     subscriptions,
                     message.id,
-                    input.getQueryInvoker().query(input.getInvocationInputFactory().create(
-                        input.getGraphQLObjectMapper().getJacksonMapper().convertValue(message.getPayload(), GraphQLRequest.class),
-                        (HandshakeRequest) session.getUserProperties().get(HandshakeRequest.class.getName())
-                    ))
+                    input.getQueryInvoker().query(graphQLSingleInvocationInput)
                 );
                 break;
 
@@ -79,6 +90,16 @@ public class ApolloSubscriptionProtocolHandler extends SubscriptionProtocolHandl
             default:
                 throw new IllegalArgumentException("Unknown message type: " + message.getType());
         }
+    }
+
+    private GraphQLSingleInvocationInput createInvocationInput(Session session, OperationMessage message) {
+        GraphQLRequest graphQLRequest = input.getGraphQLObjectMapper()
+                .getJacksonMapper()
+                .convertValue(message.getPayload(), GraphQLRequest.class);
+        HandshakeRequest handshakeRequest = (HandshakeRequest) session.getUserProperties()
+                .get(HandshakeRequest.class.getName());
+
+        return input.getInvocationInputFactory().create(graphQLRequest, session, handshakeRequest);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/graphql/servlet/internal/ApolloSubscriptionProtocolHandler.java
+++ b/src/main/java/graphql/servlet/internal/ApolloSubscriptionProtocolHandler.java
@@ -56,8 +56,14 @@ public class ApolloSubscriptionProtocolHandler extends SubscriptionProtocolHandl
 
         switch(message.getType()) {
             case GQL_CONNECTION_INIT:
-                Optional<Object> connectionResponse = connectionListener.onConnect(message.getPayload());
-                connectionResponse.ifPresent(it -> session.getUserProperties().put(ApolloSubscriptionConnectionListener.CONNECT_RESULT_KEY, it));
+                try {
+                    Optional<Object> connectionResponse = connectionListener.onConnect(message.getPayload());
+                    connectionResponse.ifPresent(it -> session.getUserProperties().put(ApolloSubscriptionConnectionListener.CONNECT_RESULT_KEY, it));
+                } catch (Throwable t) {
+                    sendMessage(session, OperationMessage.Type.GQL_ERROR, t.getMessage());
+                    return;
+                }
+
                 sendMessage(session, OperationMessage.Type.GQL_CONNECTION_ACK, message.getId());
 
                 if (connectionListener.isKeepAliveEnabled()) {

--- a/src/main/java/graphql/servlet/internal/ApolloSubscriptionProtocolHandler.java
+++ b/src/main/java/graphql/servlet/internal/ApolloSubscriptionProtocolHandler.java
@@ -60,7 +60,7 @@ public class ApolloSubscriptionProtocolHandler extends SubscriptionProtocolHandl
                     Optional<Object> connectionResponse = connectionListener.onConnect(message.getPayload());
                     connectionResponse.ifPresent(it -> session.getUserProperties().put(ApolloSubscriptionConnectionListener.CONNECT_RESULT_KEY, it));
                 } catch (Throwable t) {
-                    sendMessage(session, OperationMessage.Type.GQL_ERROR, t.getMessage());
+                    sendMessage(session, OperationMessage.Type.GQL_CONNECTION_ERROR, t.getMessage());
                     return;
                 }
 

--- a/src/main/java/graphql/servlet/internal/SubscriptionHandlerInput.java
+++ b/src/main/java/graphql/servlet/internal/SubscriptionHandlerInput.java
@@ -3,17 +3,22 @@ package graphql.servlet.internal;
 import graphql.servlet.GraphQLInvocationInputFactory;
 import graphql.servlet.GraphQLObjectMapper;
 import graphql.servlet.GraphQLQueryInvoker;
+import graphql.servlet.SubscriptionConnectionListener;
+
+import java.util.Optional;
 
 public class SubscriptionHandlerInput {
 
     private final GraphQLInvocationInputFactory invocationInputFactory;
     private final GraphQLQueryInvoker queryInvoker;
     private final GraphQLObjectMapper graphQLObjectMapper;
+    private final SubscriptionConnectionListener subscriptionConnectionListener;
 
-    public SubscriptionHandlerInput(GraphQLInvocationInputFactory invocationInputFactory, GraphQLQueryInvoker queryInvoker, GraphQLObjectMapper graphQLObjectMapper) {
+    public SubscriptionHandlerInput(GraphQLInvocationInputFactory invocationInputFactory, GraphQLQueryInvoker queryInvoker, GraphQLObjectMapper graphQLObjectMapper, SubscriptionConnectionListener subscriptionConnectionListener) {
         this.invocationInputFactory = invocationInputFactory;
         this.queryInvoker = queryInvoker;
         this.graphQLObjectMapper = graphQLObjectMapper;
+        this.subscriptionConnectionListener = subscriptionConnectionListener;
     }
 
     public GraphQLInvocationInputFactory getInvocationInputFactory() {
@@ -26,5 +31,9 @@ public class SubscriptionHandlerInput {
 
     public GraphQLObjectMapper getGraphQLObjectMapper() {
         return graphQLObjectMapper;
+    }
+
+    public Optional<SubscriptionConnectionListener> getSubscriptionConnectionListener() {
+        return Optional.ofNullable(subscriptionConnectionListener);
     }
 }

--- a/src/test/groovy/graphql/servlet/AbstractGraphQLHttpServletSpec.groovy
+++ b/src/test/groovy/graphql/servlet/AbstractGraphQLHttpServletSpec.groovy
@@ -1021,7 +1021,7 @@ class AbstractGraphQLHttpServletSpec extends Specification {
 
         setup:
         Instrumentation expectedInstrumentation = Mock()
-        GraphQLContext context = new GraphQLContext(request, response, null, null)
+        GraphQLContext context = new GraphQLContext(request, response, null, null, null)
         SimpleGraphQLHttpServlet simpleGraphQLServlet = SimpleGraphQLHttpServlet
                 .newBuilder(TestUtils.createGraphQlSchema())
                 .withQueryInvoker(GraphQLQueryInvoker.newBuilder().withInstrumentation(expectedInstrumentation).build())
@@ -1037,7 +1037,7 @@ class AbstractGraphQLHttpServletSpec extends Specification {
     def "getInstrumentation returns the ChainedInstrumentation if DataLoader provided in context"() {
         setup:
         Instrumentation servletInstrumentation = Mock()
-        GraphQLContext context = new GraphQLContext(request, response, null, null)
+        GraphQLContext context = new GraphQLContext(request, response, null, null, null)
         DataLoaderRegistry dlr = Mock()
         context.setDataLoaderRegistry(dlr)
         SimpleGraphQLHttpServlet simpleGraphQLServlet = SimpleGraphQLHttpServlet


### PR DESCRIPTION
Introduced a `ConnectionSubscriptionListener` that provides the ability to handle the `onConnect`. See also: https://www.apollographql.com/docs/graphql-subscriptions/authentication.html.

If `onConnect` returns an `Object` it is set in the `Session.userProperties`, which in turn is used now when building the `GraphQLContext`. It's currently available through `GraphQLContext.getConnectResult()`. 

`GraphQLContext` could be improved by splitting it up in separate context implementations instead of this version, but left that for a different case.

The default implementation provided here does nothing. If you want to add authorization using these features you would have to provide an implementation of `ApolloSubscriptionConnectionListener` that would handle the authorization and throws a `RuntimeException` if authorization wasn't successful. If the user could be authenticated it could return a custom object representing the principal which in turn would be made available in the `GraphQLContext`. 

By providing your own custom `GraphQLContextBuilder` as well you could align it with your own user types obviously.
