### PR TITLE
Attempt to make the OSGi example work with the latest version of graphql-java-servlet

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compileOnly 'biz.aQute.bnd:biz.aQute.bndlib:3.1.0'
 
     // Servlet
-    compile 'javax.servlet:javax.servlet-api:4.0.0'
+    compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'javax.websocket:javax.websocket-api:1.1'
 
     // GraphQL

--- a/examples/osgi/apache-karaf-feature/pom.xml
+++ b/examples/osgi/apache-karaf-feature/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.graphql-java</groupId>
+        <groupId>com.graphql-java-kickstart</groupId>
         <artifactId>graphql-java-servlet-osgi-examples</artifactId>
-        <version>3.0.1</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>graphql-java-servlet-osgi-examples-karaf-feature</artifactId>
@@ -17,22 +17,22 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.8.11.1</version>
+            <version>2.8.11</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.11.1</version>
+            <version>2.8.11</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11.1</version>
+            <version>2.8.11</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.8.11.1</version>
+            <version>2.8.11</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -47,11 +47,11 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.5.1</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>
-            <groupId>com.graphql-java</groupId>
+            <groupId>com.graphql-java-kickstart</groupId>
             <artifactId>graphql-java-servlet</artifactId>
             <version>${graphql.java.servlet.version}</version>
         </dependency>
@@ -67,11 +67,20 @@
         </dependency>
 
         <dependency>
-            <groupId>com.graphql-java</groupId>
+            <groupId>com.graphql-java-kickstart</groupId>
             <artifactId>graphql-java-servlet-osgi-examples-providers</artifactId>
             <version>${project.version}</version>
         </dependency>
-
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.25</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>1.7.25</version>
+		</dependency>
     </dependencies>
 
     <build>
@@ -87,7 +96,18 @@
                     <includeTransitiveDependency>true</includeTransitiveDependency>
                 </configuration>
             </plugin>
-        </plugins>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-install-plugin</artifactId>
+				<version>2.5.2</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.8.2</version>
+			</plugin>
+		</plugins>
 
     </build>
 

--- a/examples/osgi/apache-karaf-package/pom.xml
+++ b/examples/osgi/apache-karaf-package/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.graphql-java</groupId>
+        <groupId>com.graphql-java-kickstart</groupId>
         <artifactId>graphql-java-servlet-osgi-examples</artifactId>
-        <version>3.0.1</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>graphql-java-servlet-osgi-examples-apache-karaf-package</artifactId>
@@ -40,7 +40,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.graphql-java</groupId>
+            <groupId>com.graphql-java-kickstart</groupId>
             <artifactId>graphql-java-servlet-osgi-examples-karaf-feature</artifactId>
             <version>${project.version}</version>
             <classifier>features</classifier>
@@ -99,6 +99,17 @@
                     </installedFeatures>
                 </configuration>
             </plugin>
-        </plugins>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-install-plugin</artifactId>
+				<version>2.5.2</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.8.2</version>
+			</plugin>
+		</plugins>
     </build>
 </project>

--- a/examples/osgi/pom.xml
+++ b/examples/osgi/pom.xml
@@ -4,15 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.graphql-java</groupId>
+    <groupId>com.graphql-java-kickstart</groupId>
     <artifactId>graphql-java-servlet-osgi-examples</artifactId>
-    <version>3.0.1</version>
+    <version>6.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
         <karaf.version>4.1.6</karaf.version>
-        <graphql.java.servlet.version>3.0.1</graphql.java.servlet.version>
-        <graphql.java.version>2.4.0</graphql.java.version>
+        <graphql.java.servlet.version>6.2.1-SNAPSHOT</graphql.java.servlet.version>
+        <graphql.java.version>10.0</graphql.java.version>
     </properties>
 
     <modules>

--- a/examples/osgi/providers/pom.xml
+++ b/examples/osgi/providers/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.graphql-java</groupId>
+        <groupId>com.graphql-java-kickstart</groupId>
         <artifactId>graphql-java-servlet-osgi-examples</artifactId>
-        <version>3.0.1</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>graphql-java-servlet-osgi-examples-providers</artifactId>
@@ -14,7 +14,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.graphql-java</groupId>
+            <groupId>com.graphql-java-kickstart</groupId>
             <artifactId>graphql-java-servlet</artifactId>
             <version>${graphql.java.servlet.version}</version>
             <scope>provided</scope>


### PR DESCRIPTION
Here are various changes I had to make.

For me, jackson 2.8.11.1 couldn't be found in https://repo.maven.apache.org/maven2, 
so I downgraded it to 2.8.11.

I changed the group IDs of the example artifacts to com.graphql-java-kickstart from
com.graphql-java to match the main artifacts

I added slf4j to the feature. This now seems to be required.

There now seems to be an incompatibility between the karaf maven plugin and the latest
maven-install-plugin:3.0.0-M1. See https://stackoverflow.com/a/52622275/518627. So I
put in specific references to the previous plugin versions in order to fix this.

The change that *actually* makes the result work is to change
the dependency on javax-servlet-api to be 3.1.0 in the build.gradle
file. Otherwise the graphql-java-servlet depends on javax-servlet-api
version 4, whereas the Pax Web Http whiteboard depends on 3.1 and so
never recognises the graphql-java-servlet component.
I appreciate that this might conflict with other requirements, but it is what is required
to make this work within Karaf. at the moment.