### PR TITLE
Upgrade graphql-java to 11.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-version = 6.2.1-SNAPSHOT
+version = 7.0.0-SNAPSHOT
 group = com.graphql-java-kickstart
 
-LIB_GRAPHQL_JAVA_VER = 10.0
+LIB_GRAPHQL_JAVA_VER = 11.0
 LIB_JACKSON_VER = 2.8.11

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 7.0.0-SNAPSHOT
+version = 6.2.1-SNAPSHOT
 group = com.graphql-java-kickstart
 
 LIB_GRAPHQL_JAVA_VER = 11.0

--- a/src/main/java/graphql/servlet/GraphQLInvocationInput.java
+++ b/src/main/java/graphql/servlet/GraphQLInvocationInput.java
@@ -3,6 +3,7 @@ package graphql.servlet;
 import graphql.ExecutionInput;
 import graphql.schema.GraphQLSchema;
 import graphql.servlet.internal.GraphQLRequest;
+import org.dataloader.DataLoaderRegistry;
 
 import javax.security.auth.Subject;
 import java.util.List;
@@ -12,6 +13,7 @@ import java.util.Optional;
  * @author Andrew Potter
  */
 public abstract class GraphQLInvocationInput {
+
     private final GraphQLSchema schema;
     private final GraphQLContext context;
     private final Object root;
@@ -39,12 +41,14 @@ public abstract class GraphQLInvocationInput {
     }
 
     protected ExecutionInput createExecutionInput(GraphQLRequest graphQLRequest) {
-        return new ExecutionInput(
-            graphQLRequest.getQuery(),
-            graphQLRequest.getOperationName(),
-            context,
-            root,
-            graphQLRequest.getVariables()
-        );
+        return ExecutionInput.newExecutionInput()
+                .query(graphQLRequest.getQuery())
+                .operationName(graphQLRequest.getOperationName())
+                .context(context)
+                .root(root)
+                .variables(graphQLRequest.getVariables())
+                .dataLoaderRegistry(context.getDataLoaderRegistry().orElse(new DataLoaderRegistry()))
+                .build();
     }
+
 }

--- a/src/main/java/graphql/servlet/GraphQLQueryInvoker.java
+++ b/src/main/java/graphql/servlet/GraphQLQueryInvoker.java
@@ -68,7 +68,7 @@ public class GraphQLQueryInvoker {
                     .map(registry -> {
                         List<Instrumentation> instrumentations = new ArrayList<>();
                         instrumentations.add(getInstrumentation.get());
-                        instrumentations.add(new DataLoaderDispatcherInstrumentation(registry, dataLoaderDispatcherInstrumentationOptionsSupplier.get()));
+                        instrumentations.add(new DataLoaderDispatcherInstrumentation(dataLoaderDispatcherInstrumentationOptionsSupplier.get()));
                         return new ChainedInstrumentation(instrumentations);
                     })
                     .map(Instrumentation.class::cast)

--- a/src/main/java/graphql/servlet/GraphQLSchemaProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLSchemaProvider.java
@@ -11,7 +11,8 @@ public interface GraphQLSchemaProvider {
         return GraphQLSchema.newSchema()
                 .query(schema.getQueryType())
                 .subscription(schema.getSubscriptionType())
-                .build(schema.getAdditionalTypes());
+                .additionalTypes(schema.getAdditionalTypes())
+                .build();
     }
 
     /**

--- a/src/main/java/graphql/servlet/OsgiGraphQLHttpServlet.java
+++ b/src/main/java/graphql/servlet/OsgiGraphQLHttpServlet.java
@@ -47,27 +47,27 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
     private PreparsedDocumentProvider preparsedDocumentProvider = NoOpPreparsedDocumentProvider.INSTANCE;
 
     private GraphQLSchemaProvider schemaProvider;
-    
+
 	private ScheduledExecutorService executor;
-	private ScheduledFuture<?> updateFuture;    
+	private ScheduledFuture<?> updateFuture;
     private int schemaUpdateDelay;
 
 	@interface Config {
 		int schema_update_delay() default 0;
 	}
-	
+
 	@Activate
 	public void activate(Config config) {
 		this.schemaUpdateDelay = config.schema_update_delay();
 		if (schemaUpdateDelay!=0)
-			executor = Executors.newSingleThreadScheduledExecutor(); 
+			executor = Executors.newSingleThreadScheduledExecutor();
 	}
-	
+
 	@Deactivate
 	public void deactivate() {
 		if (executor!=null) executor.shutdown();
 	}
-	
+
     @Override
     protected GraphQLQueryInvoker getQueryInvoker() {
         return queryInvoker;
@@ -106,18 +106,18 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
     		doUpdateSchema();
     	}
     	else {
-    		if (updateFuture!=null) 
+    		if (updateFuture!=null)
     			updateFuture.cancel(true);
-    		
+
     		updateFuture = executor.schedule(new Runnable() {
 				@Override
 				public void run() {
 					doUpdateSchema();
 				}
-			}, schemaUpdateDelay, TimeUnit.MILLISECONDS);    		
+			}, schemaUpdateDelay, TimeUnit.MILLISECONDS);
     	}
     }
-    
+
     private void doUpdateSchema() {
         final GraphQLObjectType.Builder queryTypeBuilder = newObject().name("Query").description("Root query type");
 
@@ -146,7 +146,10 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
             }
         }
 
-        this.schemaProvider = new DefaultGraphQLSchemaProvider(newSchema().query(queryTypeBuilder.build()).mutation(mutationType).build(types));
+        this.schemaProvider = new DefaultGraphQLSchemaProvider(newSchema().query(queryTypeBuilder.build())
+                .mutation(mutationType)
+                .additionalTypes(types)
+                .build());
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)

--- a/src/test/groovy/graphql/servlet/AbstractGraphQLHttpServletSpec.groovy
+++ b/src/test/groovy/graphql/servlet/AbstractGraphQLHttpServletSpec.groovy
@@ -2,8 +2,10 @@ package graphql.servlet
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.Scalars
-import graphql.execution.ExecutionTypeInfo
+import graphql.annotations.annotationTypes.GraphQLType
+import graphql.execution.ExecutionStepInfo
 import graphql.execution.instrumentation.ChainedInstrumentation
+
 import graphql.execution.instrumentation.Instrumentation
 import graphql.schema.GraphQLNonNull
 import org.dataloader.DataLoaderRegistry
@@ -990,7 +992,7 @@ class AbstractGraphQLHttpServletSpec extends Specification {
 
     def "typeInfo is serialized correctly"() {
         expect:
-        servlet.getGraphQLObjectMapper().getJacksonMapper().writeValueAsString(ExecutionTypeInfo.newTypeInfo().type(new GraphQLNonNull(Scalars.GraphQLString)).build()) != "{}"
+        servlet.getGraphQLObjectMapper().getJacksonMapper().writeValueAsString(ExecutionStepInfo.newExecutionStepInfo().type(new GraphQLNonNull(Scalars.GraphQLString)).build()) != "{}"
     }
 
     @Ignore


### PR DESCRIPTION
Upgraded graphql-java version to 11.0 and reworked `DataLoaderRegistry`. See https://github.com/graphql-java/graphql-java/releases/tag/v11.0 for further details from the graphql-java side. The way to use data loaders with graphql-java-servlet doesn't change with this update.