### PR TITLE
Method for requesting number of subscriptions

### DIFF
--- a/src/main/java/graphql/servlet/GraphQLWebsocketServlet.java
+++ b/src/main/java/graphql/servlet/GraphQLWebsocketServlet.java
@@ -181,4 +181,10 @@ public class GraphQLWebsocketServlet extends Endpoint {
     public int getSessionCount() {
         return sessionSubscriptionCache.size();
     }
+
+    public int getSubscriptionCount() {
+        return sessionSubscriptionCache.values().stream()
+                .mapToInt(subscriptions -> subscriptions.getSubscriptionCount())
+                .sum();
+    }
 }

--- a/src/main/java/graphql/servlet/internal/WsSessionSubscriptions.java
+++ b/src/main/java/graphql/servlet/internal/WsSessionSubscriptions.java
@@ -50,4 +50,6 @@ public class WsSessionSubscriptions {
     private String getImplicitId(Subscription subscription) {
         return String.valueOf(subscription.hashCode());
     }
+
+    public int getSubscriptionCount() { return subscriptions.size(); }
 }


### PR DESCRIPTION
Similarly to graphql-java-kickstart/graphql-java-servlet#124, adds a method to able to grab the total number of active subscriptions.

Hope to use this with a MeterBinder in a Spring application for metrics.