### PR TITLE
Jackson mapper default property inclusion should be "ALWAYS" to prevent null values from being omitted in query results

### DIFF
--- a/src/main/java/graphql/servlet/GraphQLObjectMapper.java
+++ b/src/main/java/graphql/servlet/GraphQLObjectMapper.java
@@ -1,5 +1,6 @@
 package graphql.servlet;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.MappingIterator;
@@ -43,8 +44,10 @@ public class GraphQLObjectMapper {
         if (result == null) { // First check (no locking)
             synchronized(this) {
                 result = mapper;
-                if (result == null) // Second check (with locking)
-                    mapper = result = objectMapperProvider.provide();
+                if (result == null) { // Second check (with locking)
+                    mapper = result = objectMapperProvider.provide().copy();
+                    mapper.setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS);
+                }
             }
         }
 


### PR DESCRIPTION
Currently, the object mapper created using `ObjectMapperProvider` & `ObjectMapperConfigurer` is unchanged before use. This includes the default property inclusion value of the `ObjectMapper`. It would never make sense to not have this value be anything other than `JsonInclude.Include.ALWAYS` since GraphQL query results are never to omit any requested property regardless of the value of the property.

In a project where both RESTful endpoints and GraphQL are used, the situation may arise where the RESTful endpoints are to omit properties from responses under certain conditions (e.g. omit all `null` values from the response). When this is the case and the project uses the same `ObjectMapper` for both the RESTful endpoints and the `GraphQLServlet`, then it would be most helpful to "ignore" the value set by the incoming `ObjectMapper`'s default property inclusion value and set it to `JsonInclude.Include.ALWAYS` instead.

This PR fixes #135 