### PR TITLE
Abstract servlet does not maintain http request data for application/graphql

### DIFF
--- a/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
+++ b/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
@@ -148,7 +148,7 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
             try {
                 if (APPLICATION_GRAPHQL.equals(request.getContentType())) {
                     String query = CharStreams.toString(request.getReader());
-                    query(queryInvoker, graphQLObjectMapper, invocationInputFactory.create(new GraphQLRequest(query, null, null)), response);
+                    query(queryInvoker, graphQLObjectMapper, invocationInputFactory.create(new GraphQLRequest(query, null, null), request, response), response);
                 } else if (request.getContentType() != null && request.getContentType().startsWith("multipart/form-data") && !request.getParts().isEmpty()) {
                     final Map<String, List<Part>> fileItems = request.getParts()
                             .stream()

--- a/src/test/groovy/graphql/servlet/AbstractGraphQLHttpServletSpec.groovy
+++ b/src/test/groovy/graphql/servlet/AbstractGraphQLHttpServletSpec.groovy
@@ -300,6 +300,21 @@ class AbstractGraphQLHttpServletSpec extends Specification {
         getResponseContent().data.echo == "test"
     }
 
+    def "query over HTTP POST body with graphql contentType maintains request object"() {
+        setup:
+        request.addHeader("Content-Type", "application/graphql")
+        request.addHeader("requestHeaderTest", "test")
+        request.setContent('query { echo(arg:"test") }'.getBytes("UTF-8"))
+
+        when:
+        servlet.doPost(request, response)
+
+        then:
+        response.getStatus() == STATUS_OK
+        response.getContentType() == CONTENT_TYPE_JSON_UTF8
+        getResponseContent().extensions.requestHeaderTest == "true"
+    }
+
     def "query over HTTP POST body with variables returns data"() {
         setup:
         request.setContent(mapper.writeValueAsBytes([

--- a/src/test/groovy/graphql/servlet/TestInstrumentation.java
+++ b/src/test/groovy/graphql/servlet/TestInstrumentation.java
@@ -1,0 +1,21 @@
+package graphql.servlet;
+
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+
+import java.util.concurrent.CompletableFuture;
+
+public class TestInstrumentation extends SimpleInstrumentation {
+    @Override
+    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters) {
+        ExecutionResultImpl.Builder builder = ExecutionResultImpl.newExecutionResult().from((ExecutionResultImpl) executionResult);
+        GraphQLContext context = parameters.getContext();
+        if (context.getHttpServletRequest().map(req -> req.getHeader("requestHeaderTest")).isPresent()) {
+            builder.addExtension("requestHeaderTest", "true");
+        }
+        return CompletableFuture.completedFuture(builder.build());
+    }
+
+}

--- a/src/test/groovy/graphql/servlet/TestUtils.groovy
+++ b/src/test/groovy/graphql/servlet/TestUtils.groovy
@@ -2,15 +2,23 @@ package graphql.servlet
 
 import com.google.common.io.ByteStreams
 import graphql.Scalars
+import graphql.execution.instrumentation.Instrumentation
 import graphql.schema.*
 
 class TestUtils {
 
     static def createServlet(DataFetcher queryDataFetcher = { env -> env.arguments.arg },
                              DataFetcher mutationDataFetcher = { env -> env.arguments.arg }) {
-        GraphQLHttpServlet servlet = GraphQLHttpServlet.with(createGraphQlSchema(queryDataFetcher, mutationDataFetcher))
+        GraphQLHttpServlet servlet = GraphQLHttpServlet.with(GraphQLConfiguration
+                .with(createGraphQlSchema(queryDataFetcher, mutationDataFetcher))
+                .with(createInstrumentedQueryInvoker()).build())
         servlet.init(null)
         return servlet
+    }
+
+    static def createInstrumentedQueryInvoker() {
+        Instrumentation instrumentation = new TestInstrumentation()
+        GraphQLQueryInvoker.newBuilder().with([instrumentation]).build()
     }
 
     static def createGraphQlSchema(DataFetcher queryDataFetcher = { env -> env.arguments.arg },


### PR DESCRIPTION
Abstract servlet does not maintain the http request for the application/graphql content type path of the post handler - this adds it in. The tests verify in a similar fashion to our use case.