### PR TITLE
Use thread pool executor for async queries

### DIFF
--- a/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
+++ b/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
@@ -51,7 +51,7 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
     private static final String[] MULTIPART_KEYS = new String[]{"operations", "graphql", "query"};
 
     private GraphQLConfiguration configuration;
-
+    
     /**
      * @deprecated override {@link #getConfiguration()} instead
      */
@@ -292,7 +292,7 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
             AsyncContext asyncContext = request.startAsync();
             HttpServletRequest asyncRequest = (HttpServletRequest) asyncContext.getRequest();
             HttpServletResponse asyncResponse = (HttpServletResponse) asyncContext.getResponse();
-            new Thread(() -> doRequest(asyncRequest, asyncResponse, handler, asyncContext)).start();
+            configuration.getAsyncExecutor().execute(() -> doRequest(asyncRequest, asyncResponse, handler, asyncContext));
         } else {
             doRequest(request, response, handler, null);
         }

--- a/src/main/java/graphql/servlet/GraphQLConfiguration.java
+++ b/src/main/java/graphql/servlet/GraphQLConfiguration.java
@@ -1,10 +1,12 @@
 package graphql.servlet;
 
 import graphql.schema.GraphQLSchema;
+import graphql.servlet.internal.GraphQLThreadFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 public class GraphQLConfiguration {
 
@@ -13,6 +15,7 @@ public class GraphQLConfiguration {
     private GraphQLObjectMapper objectMapper;
     private List<GraphQLServletListener> listeners;
     private boolean asyncServletModeEnabled;
+    private Executor asyncExecutor;
 
     public static GraphQLConfiguration.Builder with(GraphQLSchema schema) {
         return with(new DefaultGraphQLSchemaProvider(schema));
@@ -26,12 +29,13 @@ public class GraphQLConfiguration {
         return new Builder(invocationInputFactory);
     }
 
-    private GraphQLConfiguration(GraphQLInvocationInputFactory invocationInputFactory, GraphQLQueryInvoker queryInvoker, GraphQLObjectMapper objectMapper, List<GraphQLServletListener> listeners, boolean asyncServletModeEnabled) {
+    private GraphQLConfiguration(GraphQLInvocationInputFactory invocationInputFactory, GraphQLQueryInvoker queryInvoker, GraphQLObjectMapper objectMapper, List<GraphQLServletListener> listeners, boolean asyncServletModeEnabled, Executor asyncExecutor) {
         this.invocationInputFactory = invocationInputFactory;
         this.queryInvoker = queryInvoker;
         this.objectMapper = objectMapper;
         this.listeners = listeners;
         this.asyncServletModeEnabled = asyncServletModeEnabled;
+        this.asyncExecutor = asyncExecutor;
     }
 
     public GraphQLInvocationInputFactory getInvocationInputFactory() {
@@ -54,6 +58,10 @@ public class GraphQLConfiguration {
         return asyncServletModeEnabled;
     }
 
+    public Executor getAsyncExecutor() {
+        return asyncExecutor;
+    }
+
     public void add(GraphQLServletListener listener) {
         listeners.add(listener);
     }
@@ -70,6 +78,7 @@ public class GraphQLConfiguration {
         private GraphQLObjectMapper objectMapper = GraphQLObjectMapper.newBuilder().build();
         private List<GraphQLServletListener> listeners = new ArrayList<>();
         private boolean asyncServletModeEnabled = false;
+        private Executor asyncExecutor = Executors.newCachedThreadPool(new GraphQLThreadFactory());
 
         private Builder(GraphQLInvocationInputFactory.Builder invocationInputFactoryBuilder) {
             this.invocationInputFactoryBuilder = invocationInputFactoryBuilder;
@@ -105,6 +114,13 @@ public class GraphQLConfiguration {
             return this;
         }
 
+        public Builder with(Executor asyncExecutor) {
+            if (asyncExecutor != null) {
+            	this.asyncExecutor = asyncExecutor;
+            }
+            return this;
+        }
+
         public Builder with(GraphQLContextBuilder contextBuilder) {
             this.invocationInputFactoryBuilder.withGraphQLContextBuilder(contextBuilder);
             return this;
@@ -121,7 +137,8 @@ public class GraphQLConfiguration {
                     queryInvoker,
                     objectMapper,
                     listeners,
-                    asyncServletModeEnabled
+                    asyncServletModeEnabled,
+                    asyncExecutor
             );
         }
 

--- a/src/main/java/graphql/servlet/GraphQLConfiguration.java
+++ b/src/main/java/graphql/servlet/GraphQLConfiguration.java
@@ -30,7 +30,7 @@ public class GraphQLConfiguration {
         return new Builder(invocationInputFactory);
     }
 
-    private GraphQLConfiguration(GraphQLInvocationInputFactory invocationInputFactory, GraphQLQueryInvoker queryInvoker, GraphQLObjectMapper objectMapper, List<GraphQLServletListener> listeners, boolean asyncServletModeEnabled, Executor asyncExecutor, , long subscriptionTimeout) {
+    private GraphQLConfiguration(GraphQLInvocationInputFactory invocationInputFactory, GraphQLQueryInvoker queryInvoker, GraphQLObjectMapper objectMapper, List<GraphQLServletListener> listeners, boolean asyncServletModeEnabled, Executor asyncExecutor, long subscriptionTimeout) {
         this.invocationInputFactory = invocationInputFactory;
         this.queryInvoker = queryInvoker;
         this.objectMapper = objectMapper;

--- a/src/main/java/graphql/servlet/internal/GraphQLThreadFactory.java
+++ b/src/main/java/graphql/servlet/internal/GraphQLThreadFactory.java
@@ -1,0 +1,26 @@
+package graphql.servlet.internal;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import graphql.servlet.AbstractGraphQLHttpServlet;
+
+/**
+ * {@link ThreadFactory} implementation for {@link AbstractGraphQLHttpServlet} async operations
+ * 
+ * @author John Nutting
+ */
+public class GraphQLThreadFactory implements ThreadFactory {
+
+	final static String NAME_PREFIX = "GraphQLServlet-";
+	final AtomicInteger threadNumber = new AtomicInteger(1);
+
+	@Override
+	public Thread newThread(final Runnable r) {
+		Thread t = new Thread(r, NAME_PREFIX + threadNumber.getAndIncrement());
+		t.setDaemon(false);
+		t.setPriority(Thread.NORM_PRIORITY);
+		return t;
+	}
+
+}

--- a/src/test/groovy/graphql/servlet/TestUtils.groovy
+++ b/src/test/groovy/graphql/servlet/TestUtils.groovy
@@ -5,7 +5,6 @@ import graphql.Scalars
 import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.reactive.SingleSubscriberPublisher
 import graphql.schema.*
-import org.reactivestreams.Publisher
 
 import java.util.concurrent.atomic.AtomicReference
 
@@ -13,15 +12,15 @@ class TestUtils {
 
     static def createServlet(DataFetcher queryDataFetcher = { env -> env.arguments.arg },
                              DataFetcher mutationDataFetcher = { env -> env.arguments.arg },
-                             boolean asyncServletModeEnabled = false) {
-         DataFetcher subscriptionDataFetcher = { env ->
-             AtomicReference<SingleSubscriberPublisher<String>> publisherRef = new AtomicReference<>();
-             publisherRef.set(new SingleSubscriberPublisher<>({ subscription ->
-                 publisherRef.get().offer(env.arguments.arg)
-                 publisherRef.get().noMoreData()
-             }))
-             return publisherRef.get()
-         }) {
+                             boolean asyncServletModeEnabled = false,
+                             DataFetcher subscriptionDataFetcher = { env ->
+                                 AtomicReference<SingleSubscriberPublisher<String>> publisherRef = new AtomicReference<>();
+                                 publisherRef.set(new SingleSubscriberPublisher<>({ subscription ->
+                                     publisherRef.get().offer(env.arguments.arg)
+                                     publisherRef.get().noMoreData()
+                                 }))
+                                 return publisherRef.get()
+                             }) {
         GraphQLHttpServlet servlet = GraphQLHttpServlet.with(GraphQLConfiguration
                 .with(createGraphQlSchema(queryDataFetcher, mutationDataFetcher, subscriptionDataFetcher))
                 .with(createInstrumentedQueryInvoker())
@@ -75,23 +74,27 @@ class TestUtils {
             }
             field.dataFetcher(mutationDataFetcher)
         }
-                .field { field ->
+        .field { field ->
             field.name("echoFile")
             field.type(Scalars.GraphQLString)
             field.argument { argument ->
                 argument.name("file")
                 argument.type(ApolloScalars.Upload)
             }
-            field.dataFetcher( { env -> new String(ByteStreams.toByteArray(env.arguments.file.getInputStream())) } )
+            field.dataFetcher({ env -> new String(ByteStreams.toByteArray(env.arguments.file.getInputStream())) })
         }
-                .field { field ->
+        .field { field ->
             field.name("echoFiles")
             field.type(GraphQLList.list(Scalars.GraphQLString))
             field.argument { argument ->
                 argument.name("files")
                 argument.type(GraphQLList.list(GraphQLNonNull.nonNull(ApolloScalars.Upload)))
             }
-            field.dataFetcher( { env -> env.arguments.files.collect { new String(ByteStreams.toByteArray(it.getInputStream())) } } )
+            field.dataFetcher({ env ->
+                env.arguments.files.collect {
+                    new String(ByteStreams.toByteArray(it.getInputStream()))
+                }
+            })
         }
         .build()
 
@@ -110,11 +113,11 @@ class TestUtils {
 
 
         return GraphQLSchema.newSchema()
-                            .query(query)
-                            .mutation(mutation)
-                            .subscription(subscription)
-                            .additionalType(ApolloScalars.Upload)
-                            .build()
+                .query(query)
+                .mutation(mutation)
+                .subscription(subscription)
+                .additionalType(ApolloScalars.Upload)
+                .build()
     }
 
 }

--- a/src/test/groovy/graphql/servlet/TestUtils.groovy
+++ b/src/test/groovy/graphql/servlet/TestUtils.groovy
@@ -8,10 +8,13 @@ import graphql.schema.*
 class TestUtils {
 
     static def createServlet(DataFetcher queryDataFetcher = { env -> env.arguments.arg },
-                             DataFetcher mutationDataFetcher = { env -> env.arguments.arg }) {
+                             DataFetcher mutationDataFetcher = { env -> env.arguments.arg },
+                             boolean asyncServletModeEnabled = false) {
         GraphQLHttpServlet servlet = GraphQLHttpServlet.with(GraphQLConfiguration
                 .with(createGraphQlSchema(queryDataFetcher, mutationDataFetcher))
-                .with(createInstrumentedQueryInvoker()).build())
+                .with(createInstrumentedQueryInvoker())
+                .with(asyncServletModeEnabled)
+                .build())
         servlet.init(null)
         return servlet
     }


### PR DESCRIPTION
When using servlet in async mode, a [new thread is created for every request](https://github.com/graphql-java-kickstart/graphql-java-servlet/blob/master/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java#L295).  The purpose of this pull request is to improve performance by using a ThreadPoolExecutor so threads will be reused.