### PR TITLE
Reordered properties in JSON response according to recommendation in GraphQL spec

### DIFF
--- a/src/main/java/graphql/servlet/GraphQLObjectMapper.java
+++ b/src/main/java/graphql/servlet/GraphQLObjectMapper.java
@@ -129,16 +129,16 @@ public class GraphQLObjectMapper {
     public Map<String, Object> convertSanitizedExecutionResult(ExecutionResult executionResult, boolean includeData) {
         final Map<String, Object> result = new LinkedHashMap<>();
 
-        if(includeData) {
-            result.put("data", executionResult.getData());
-        }
-
         if (areErrorsPresent(executionResult)) {
             result.put("errors", executionResult.getErrors());
         }
 
         if(executionResult.getExtensions() != null){
             result.put("extensions", executionResult.getExtensions());
+        }
+
+        if(includeData) {
+            result.put("data", executionResult.getData());
         }
 
         return result;


### PR DESCRIPTION
[In the official GraphQL spec, it says the following](https://facebook.github.io/graphql/June2018/#sec-Response-Format):

> When `errors` is present in the response, it may be helpful for it to appear first when serialized to make it more clear when errors are present in a response during debugging.

In my own personal debugging, I've found that my teammates and I often overlook `errors` because the property is located after `data`. The same goes for `extensions`. This pull request changes the response message property order to the following:

- `errors`
- `extensions`
- `data`