### PR TITLE
GraphQLSchemaProvider#copyReadOnly: simpler, supports CodeRegistry

### DIFF
--- a/src/main/java/graphql/servlet/GraphQLSchemaProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLSchemaProvider.java
@@ -1,5 +1,6 @@
 package graphql.servlet;
 
+import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 
 import javax.servlet.http.HttpServletRequest;
@@ -8,10 +9,8 @@ import javax.websocket.server.HandshakeRequest;
 public interface GraphQLSchemaProvider {
 
     static GraphQLSchema copyReadOnly(GraphQLSchema schema) {
-        return GraphQLSchema.newSchema()
-                .query(schema.getQueryType())
-                .subscription(schema.getSubscriptionType())
-                .additionalTypes(schema.getAdditionalTypes())
+        return GraphQLSchema.newSchema(schema)
+                .mutation((GraphQLObjectType) null)
                 .build();
     }
 


### PR DESCRIPTION
Fixes support for the code registry (as opposed to type resolvers & data fetchers attached directly to schema objects).
```
Caused by: graphql.AssertException: There must be a type resolver for union ExampleUnion
	at graphql.Assert.assertNotNull(Assert.java:15) ~[graphql-java-12.0.jar:na]
[…]
	at graphql.schema.GraphQLCodeRegistry$Builder.getTypeResolver(GraphQLCodeRegistry.java:230) ~[graphql-java-12.0.jar:na]
[…]
	at graphql.schema.SchemaUtil.extractCodeFromTypes(SchemaUtil.java:112) ~[graphql-java-12.0.jar:na]
[…]
	at graphql.schema.GraphQLCodeRegistry.transform(GraphQLCodeRegistry.java:139) ~[graphql-java-12.0.jar:na]
	at graphql.schema.GraphQLSchema$Builder.build(GraphQLSchema.java:413) ~[graphql-java-12.0.jar:na]
	at graphql.servlet.GraphQLSchemaProvider.copyReadOnly(GraphQLSchemaProvider.java:15) ~[graphql-java-servlet-7.4.1.jar:na]
	at graphql.servlet.DefaultGraphQLSchemaProvider.<init>(DefaultGraphQLSchemaProvider.java:17) ~[graphql-java-servlet-7.4.1.jar:na]
	at com.oembedler.moon.graphql.boot.GraphQLWebAutoConfiguration.graphQLSchemaProvider(GraphQLWebAutoConfiguration.java:162) ~[graphql-spring-boot-autoconfigure-5.8.1.jar:na]
```

Signed-off-by: Pierre Carrier <pc@rrier.ca>