### PR TITLE
separated out logging of errors to separate overriddable method in DefaultGraphQLErrorHandler

### DIFF
--- a/src/main/java/graphql/servlet/DefaultGraphQLErrorHandler.java
+++ b/src/main/java/graphql/servlet/DefaultGraphQLErrorHandler.java
@@ -26,18 +26,20 @@ public class DefaultGraphQLErrorHandler implements GraphQLErrorHandler {
 
             errors.stream()
                     .filter(error -> !isClientError(error))
-                    .forEach(error -> {
-                        if (error instanceof Throwable) {
-                            log.error("Error executing query!", (Throwable) error);
-                        } else if (error instanceof ExceptionWhileDataFetching) {
-                            log.error("Error executing query {}", error.getMessage(), ((ExceptionWhileDataFetching) error).getException());
-                        } else {
-                            log.error("Error executing query ({}): {}", error.getClass().getSimpleName(), error.getMessage());
-                        }
-                    });
+                    .forEach(this::logError);
         }
 
         return clientErrors;
+    }
+
+    protected void logError(GraphQLError error) {
+        if (error instanceof Throwable) {
+            log.error("Error executing query!", (Throwable) error);
+        } else if (error instanceof ExceptionWhileDataFetching) {
+            log.error("Error executing query {}", error.getMessage(), ((ExceptionWhileDataFetching) error).getException());
+        } else {
+            log.error("Error executing query ({}): {}", error.getClass().getSimpleName(), error.getMessage());
+        }
     }
 
     protected List<GraphQLError> filterGraphQLErrors(List<GraphQLError> errors) {


### PR DESCRIPTION
## What was changed?
Separated out logging of errors to separate overriddable method in DefaultGraphQLErrorHandler so that entire processErrors method does not need to be overridden just to change which errors get logged by users of DefaultGraphQLErrorHandler.

## Why?
When a user of this library wants to override DefaultGraphQLErrorHandler to create their own but retain the functionality of DefaultGraphQLErrorHandler without copying the code, that user cannot change which errors are logged unless they reimplement the entire processErrors method. This PR separates out the logging of errors into a separate method that can be overridden to prevent the need to reimplement all of processErrors just to change which errors are logged.