### PR TITLE
Defer support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     // Servlet
     compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'javax.websocket:javax.websocket-api:1.1'
+    compile 'io.projectreactor:reactor-core:3.0.5.RELEASE'
 
     // GraphQL
     compile "com.graphql-java:graphql-java:$LIB_GRAPHQL_JAVA_VER"

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     // Servlet
     compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'javax.websocket:javax.websocket-api:1.1'
-    compile 'io.projectreactor:reactor-core:3.0.5.RELEASE'
 
     // GraphQL
     compile "com.graphql-java:graphql-java:$LIB_GRAPHQL_JAVA_VER"

--- a/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
+++ b/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
@@ -385,7 +385,7 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
             } else {
                 publisher = new SingleSubscriberPublisher<>();
                 ((SingleSubscriberPublisher<ExecutionResult>) publisher).offer(result);
-                publisher = new MultiPublisher(publisher, (Publisher<DeferredExecutionResult>) result.getExtensions().get(GraphQL.DEFERRED_RESULTS));
+                publisher = new MultiPublisher<>(publisher, (Publisher<ExecutionResult>) result.getExtensions().get(GraphQL.DEFERRED_RESULTS));
             }
             publisher.subscribe(subscriber);
             if (isInAsyncThread) {

--- a/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
+++ b/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
@@ -585,6 +585,7 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
         StaticDataPublisher(T data) {
             super();
             super.offer(data);
+            super.noMoreData();
         }
     }
 

--- a/src/test/groovy/graphql/servlet/AbstractGraphQLHttpServletSpec.groovy
+++ b/src/test/groovy/graphql/servlet/AbstractGraphQLHttpServletSpec.groovy
@@ -286,7 +286,7 @@ class AbstractGraphQLHttpServletSpec extends Specification {
 
     def "deferred query over HTTP GET"() {
         setup:
-        request.addParameter('query', 'query { deferred(arg:"test") @defer }')
+        request.addParameter('query', 'query { echo(arg:"test") @defer }')
 
         when:
         servlet.doGet(request, response)
@@ -294,7 +294,7 @@ class AbstractGraphQLHttpServletSpec extends Specification {
         then:
         response.getStatus() == STATUS_OK
         response.getContentType() == CONTENT_TYPE_SERVER_SENT_EVENTS
-        getSubscriptionResponseContent()[0].data.deferred == null
+        getSubscriptionResponseContent()[0].data.echo == null
 
         when:
         subscriptionLatch.await(1, TimeUnit.SECONDS)
@@ -302,7 +302,7 @@ class AbstractGraphQLHttpServletSpec extends Specification {
         then:
         def content = getSubscriptionResponseContent()
         content[1].data == "test"
-        content[1].path == ["deferred"]
+        content[1].path == ["echo"]
     }
 
     def "Batch Execution Handler allows limiting batches and sending error messages."() {
@@ -1056,7 +1056,7 @@ class AbstractGraphQLHttpServletSpec extends Specification {
         setup:
         servlet = TestUtils.createDefaultServlet()
         request.setContent(mapper.writeValueAsBytes([
-                query: 'query { deferred(arg:"test") @defer }'
+                query: 'query { echo(arg:"test") @defer }'
         ]))
         request.setAsyncSupported(true)
 
@@ -1066,7 +1066,7 @@ class AbstractGraphQLHttpServletSpec extends Specification {
         then:
         response.getStatus() == STATUS_OK
         response.getContentType() == CONTENT_TYPE_SERVER_SENT_EVENTS
-        getSubscriptionResponseContent()[0].data.deferred == null
+        getSubscriptionResponseContent()[0].data.echo == null
 
         when:
         subscriptionLatch.await(1, TimeUnit.SECONDS)
@@ -1074,7 +1074,7 @@ class AbstractGraphQLHttpServletSpec extends Specification {
         then:
         def content = getSubscriptionResponseContent()
         content[1].data == "test"
-        content[1].path == ["deferred"]
+        content[1].path == ["echo"]
     }
 
     def "errors before graphql schema execution return internal server error"() {

--- a/src/test/groovy/graphql/servlet/TestUtils.groovy
+++ b/src/test/groovy/graphql/servlet/TestUtils.groovy
@@ -120,20 +120,6 @@ class TestUtils {
             field.type(new GraphQLNonNull(Scalars.GraphQLString))
             field.dataFetcher({ env -> null })
         }
-        .field { GraphQLFieldDefinition.Builder field ->
-            field.name("deferred")
-            field.type(Scalars.GraphQLString)
-            field.argument { argument ->
-                argument.name("arg")
-                argument.type(Scalars.GraphQLString)
-            }
-            field.dataFetcher({ env ->
-                return CompletableFuture.supplyAsync( {
-                    Thread.sleep(100)
-                    env.arguments.arg
-                })
-            })
-        }
         .build()
 
         GraphQLObjectType mutation = GraphQLObjectType.newObject()

--- a/src/test/groovy/graphql/servlet/TestUtils.groovy
+++ b/src/test/groovy/graphql/servlet/TestUtils.groovy
@@ -116,6 +116,32 @@ class TestUtils {
             field.dataFetcher(queryDataFetcher)
         }
         .field { GraphQLFieldDefinition.Builder field ->
+            field.name("object")
+            field.type(
+                GraphQLObjectType.newObject()
+                    .name("NestedObject")
+                    .field { nested ->
+                        nested.name("a")
+                        nested.type(Scalars.GraphQLString)
+                        nested.argument { argument ->
+                            argument.name("arg")
+                            argument.type(Scalars.GraphQLString)
+                        }
+                        nested.dataFetcher(queryDataFetcher)
+                    }
+                    .field { nested ->
+                        nested.name("b")
+                        nested.type(Scalars.GraphQLString)
+                        nested.argument { argument ->
+                            argument.name("arg")
+                            argument.type(Scalars.GraphQLString)
+                        }
+                        nested.dataFetcher(queryDataFetcher)
+                    }
+            )
+            field.dataFetcher(new StaticDataFetcher([:]))
+        }
+        .field { GraphQLFieldDefinition.Builder field ->
             field.name("returnsNullIncorrectly")
             field.type(new GraphQLNonNull(Scalars.GraphQLString))
             field.dataFetcher({ env -> null })


### PR DESCRIPTION
An initial attempt at adding `@defer` directive support #133. Similar to the [apollo spec](https://github.com/apollographql/apollo-server/blob/defer-support/docs/source/defer-support.md), although currently without the specified line ending `CRLF + "-----" + CRLF `. I still have to integration test this.

### Additional Links
1. [GraphQLJava @defer example](https://github.com/graphql-java/graphql-java-examples/blob/master/defer/server/src/main/java/com/graphqljava/defer/GraphQLController.java#L104)