### PR TITLE
Add Content-Length HTTP header for non-stream JSON responses.

### DIFF
--- a/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
+++ b/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
@@ -364,7 +364,9 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
         if (!(result.getData() instanceof Publisher || isDeferred)) {
             resp.setContentType(APPLICATION_JSON_UTF8);
             resp.setStatus(STATUS_OK);
-            resp.getWriter().write(graphQLObjectMapper.serializeResultAsJson(result));
+            String responseContent = graphQLObjectMapper.serializeResultAsJson(result);
+            resp.setContentLength(responseContent.length());
+            resp.getWriter().write(responseContent);
         } else {
             if (req == null) {
                 throw new IllegalStateException("Http servlet request can not be null");
@@ -409,17 +411,20 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
                     contextSetting);
             response.setContentType(AbstractGraphQLHttpServlet.APPLICATION_JSON_UTF8);
             response.setStatus(AbstractGraphQLHttpServlet.STATUS_OK);
-            Writer writer = response.getWriter();
             Iterator<ExecutionResult> executionInputIterator = results.iterator();
-            writer.write("[");
+            StringBuilder responseBuilder = new StringBuilder();
+            responseBuilder.append('[');
             GraphQLObjectMapper graphQLObjectMapper = configuration.getObjectMapper();
             while (executionInputIterator.hasNext()) {
-                writer.write(graphQLObjectMapper.serializeResultAsJson(executionInputIterator.next()));
+                responseBuilder.append(graphQLObjectMapper.serializeResultAsJson(executionInputIterator.next()));
                 if (executionInputIterator.hasNext()) {
-                    writer.write(",");
+                    responseBuilder.append(',');
                 }
             }
-            writer.write("]");
+            responseBuilder.append(']');
+            String responseContent = responseBuilder.toString();
+            response.setContentLength(responseContent.length());
+            response.getWriter().write(responseContent);
         } else {
             response.sendError(batchInputPreProcessResult.getStatusCode(), batchInputPreProcessResult.getStatusMessage());
         }

--- a/src/test/groovy/graphql/servlet/AbstractGraphQLHttpServletSpec.groovy
+++ b/src/test/groovy/graphql/servlet/AbstractGraphQLHttpServletSpec.groovy
@@ -108,6 +108,7 @@ class AbstractGraphQLHttpServletSpec extends Specification {
         then:
         response.getStatus() == STATUS_OK
         response.getContentType() == CONTENT_TYPE_JSON_UTF8
+        response.getContentLength() == mapper.writeValueAsString(["data":["echo":"test"]]).length()
         getResponseContent().data.echo == "test"
     }
 
@@ -729,6 +730,7 @@ class AbstractGraphQLHttpServletSpec extends Specification {
         then:
         response.getStatus() == STATUS_OK
         response.getContentType() == CONTENT_TYPE_JSON_UTF8
+        response.getContentLength() == mapper.writeValueAsString([["data": ["echo": "test"]], ["data": ["echo": "test"]]]).length()
         getBatchedResponseContent()[0].data.echo == "test"
         getBatchedResponseContent()[1].data.echo == "test"
     }


### PR DESCRIPTION
This helps clients decode more efficiently HTTP responses.

I have left out the stream responses because I think the header doesn't apply there.

Also I have covered only the happy path (successful response), it seems errors are implicitly supposed to return a Content-Length of 0.