### PR TITLE
Serialize query response directly to Servlet's output stream to avoid intermediate String object creation

### DIFF
--- a/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
+++ b/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
@@ -364,7 +364,7 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
         if (!(result.getData() instanceof Publisher || isDeferred)) {
             resp.setContentType(APPLICATION_JSON_UTF8);
             resp.setStatus(STATUS_OK);
-            resp.getWriter().write(graphQLObjectMapper.serializeResultAsJson(result));
+            graphQLObjectMapper.serializeResultAsJson(resp.getWriter(), result);
         } else {
             if (req == null) {
                 throw new IllegalStateException("Http servlet request can not be null");
@@ -414,7 +414,7 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
             writer.write("[");
             GraphQLObjectMapper graphQLObjectMapper = configuration.getObjectMapper();
             while (executionInputIterator.hasNext()) {
-                writer.write(graphQLObjectMapper.serializeResultAsJson(executionInputIterator.next()));
+                graphQLObjectMapper.serializeResultAsJson(writer, executionInputIterator.next());
                 if (executionInputIterator.hasNext()) {
                     writer.write(",");
                 }
@@ -558,7 +558,9 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
         public void onNext(ExecutionResult executionResult) {
             try {
                 Writer writer = asyncContext.getResponse().getWriter();
-                writer.write("data: " + graphQLObjectMapper.serializeResultAsJson(executionResult) + "\n\n");
+                writer.write("data: ");
+                graphQLObjectMapper.serializeResultAsJson(writer, executionResult);
+                writer.write("\n\n");
                 writer.flush();
                 subscriptionRef.get().request(1);
             } catch (IOException ignored) {

--- a/src/main/java/graphql/servlet/core/GraphQLObjectMapper.java
+++ b/src/main/java/graphql/servlet/core/GraphQLObjectMapper.java
@@ -16,6 +16,7 @@ import graphql.servlet.core.internal.VariablesDeserializer;
 import javax.servlet.http.Part;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -99,6 +100,10 @@ public class GraphQLObjectMapper {
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public void serializeResultAsJson(Writer writer, ExecutionResult executionResult) throws IOException {
+        getJacksonMapper().writeValue(writer, createResultFromExecutionResult(executionResult));
     }
 
     public boolean areErrorsPresent(ExecutionResult executionResult) {


### PR DESCRIPTION
I checked this improvement using this test `customers` query https://github.com/shailender-bathula/samples/commit/fd1bf6d64aa5a087ad81293b5d94b64234028ba1 and [bombardier](https://github.com/codesenberg/bombardier) HTTP benchmarking tool.

I ran the application using the default settings i.e. `../gradlew appRun` and benchmarking like this:
`bombardier --method POST --header "Content-Type: application/json" --duration=70s --connections=110 --body '{ "query": "{ customers {id firstName lastName yearOfBirth email} }" }' http://localhost:8080/servlet-hello-world/graphql`

There was an improvement of 5 - 10 requests/second before and after in those tests. The difference may be more in higher throughput environments.
