### PR TITLE
Fix: Erroneous calculation of content-length can lead to errors on …

### DIFF
--- a/graphql-java-servlet/src/main/java/graphql/servlet/SingleQueryResponseWriter.java
+++ b/graphql-java-servlet/src/main/java/graphql/servlet/SingleQueryResponseWriter.java
@@ -6,6 +6,8 @@ import static graphql.servlet.HttpRequestHandler.STATUS_OK;
 import graphql.ExecutionResult;
 import graphql.kickstart.execution.GraphQLObjectMapper;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +23,7 @@ class SingleQueryResponseWriter implements QueryResponseWriter {
     response.setContentType(APPLICATION_JSON_UTF8);
     response.setStatus(STATUS_OK);
     String responseContent = graphQLObjectMapper.serializeResultAsJson(result);
-    response.setContentLength(responseContent.length());
+    response.setContentLength(responseContent.getBytes(StandardCharsets.UTF_8).length);
     response.getWriter().write(responseContent);
   }
 


### PR DESCRIPTION
…client-side due to chopping of JSON reponse in certain situations (problem related to character encoding). Length must contain the number of bytes calculated using the expected response encoding, instead of the number of characters.
Problem already leads to errors when using some special Unicode characters within response content.