### PR TITLE
fix content length on batched queries

### DIFF
--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/BatchedQueryResponseWriter.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/BatchedQueryResponseWriter.java
@@ -3,6 +3,7 @@ package graphql.kickstart.servlet;
 import graphql.ExecutionResult;
 import graphql.kickstart.execution.GraphQLObjectMapper;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
@@ -32,7 +33,7 @@ class BatchedQueryResponseWriter implements QueryResponseWriter {
     responseBuilder.append(']');
 
     String responseContent = responseBuilder.toString();
-    response.setContentLength(responseContent.length());
+    response.setContentLength(responseContent.getBytes(StandardCharsets.UTF_8).length);
     response.getWriter().write(responseContent);
   }
 


### PR DESCRIPTION
Related to https://github.com/graphql-java-kickstart/graphql-java-servlet/issues/220 but for batched queries
Also updated the tests to check contentLength accordingly.