### PR TITLE
Added OSGi metadata to kickstart artefact

### DIFF
--- a/graphql-java-kickstart/bnd.bnd
+++ b/graphql-java-kickstart/bnd.bnd
@@ -1,0 +1,1 @@
+Export-Package: graphql.kickstart.*

--- a/graphql-java-kickstart/build.gradle
+++ b/graphql-java-kickstart/build.gradle
@@ -1,3 +1,9 @@
+apply plugin: 'biz.aQute.bnd.builder'
+
+jar {
+    bndfile = 'bnd.bnd'
+}
+
 dependencies {
     // GraphQL
     compile "com.graphql-java:graphql-java:$LIB_GRAPHQL_JAVA_VER"

--- a/graphql-java-servlet/bnd.bnd
+++ b/graphql-java-servlet/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: graphql.kickstart.*
+Require-Capability: osgi.extender

--- a/graphql-java-servlet/build.gradle
+++ b/graphql-java-servlet/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'java-library-distribution'
 apply plugin: 'biz.aQute.bnd.builder'
 
 jar {
-    bnd ('Require-Capability': 'osgi.extender')
+    bndfile = 'bnd.bnd'
 }
 
 dependencies {


### PR DESCRIPTION
When the servlet bundle is loaded in an OSGi environment it is missing the kickstart packages, however the kickstart JAR doesn't include OSGi metadata. This PR provides a fix.

Also the BND config was externalised from the gradle script for easier management.