### PR TITLE
Feature/osgi servlet config

### DIFF
--- a/graphql-java-kickstart/bnd.bnd
+++ b/graphql-java-kickstart/bnd.bnd
@@ -1,0 +1,1 @@
+Export-Package: graphql.kickstart.*

--- a/graphql-java-kickstart/build.gradle
+++ b/graphql-java-kickstart/build.gradle
@@ -1,3 +1,9 @@
+apply plugin: 'biz.aQute.bnd.builder'
+
+jar {
+    bndfile = 'bnd.bnd'
+}
+
 dependencies {
     // GraphQL
     compile "com.graphql-java:graphql-java:$LIB_GRAPHQL_JAVA_VER"

--- a/graphql-java-servlet/bnd.bnd
+++ b/graphql-java-servlet/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: graphql.kickstart.*
+Require-Capability: osgi.extender

--- a/graphql-java-servlet/build.gradle
+++ b/graphql-java-servlet/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'java-library-distribution'
 apply plugin: 'biz.aQute.bnd.builder'
 
 jar {
-    bnd ('Require-Capability': 'osgi.extender')
+    bndfile = 'bnd.bnd'
 }
 
 dependencies {

--- a/graphql-java-servlet/build.gradle
+++ b/graphql-java-servlet/build.gradle
@@ -24,7 +24,9 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.core:6.0.0'
     compileOnly 'org.osgi:org.osgi.service.cm:1.5.0'
     compileOnly 'org.osgi:org.osgi.service.component:1.3.0'
-    compileOnly 'biz.aQute.bnd:biz.aQute.bndlib:4.3.1'
+    compileOnly 'org.osgi:org.osgi.service.component.annotations:1.3.0'
+    compileOnly 'org.osgi:org.osgi.service.metatype.annotations:1.3.0'
+    compileOnly 'org.osgi:org.osgi.annotation:6.0.0'
 
     testCompile 'io.github.graphql-java:graphql-java-annotations:5.2'
 

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/OsgiGraphQLHttpServlet.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/OsgiGraphQLHttpServlet.java
@@ -3,13 +3,13 @@ package graphql.kickstart.servlet;
 import static graphql.schema.GraphQLObjectType.newObject;
 import static graphql.schema.GraphQLSchema.newSchema;
 
-import aQute.bnd.component.annotations.Activate;
-import aQute.bnd.component.annotations.Component;
-import aQute.bnd.component.annotations.Deactivate;
-import aQute.bnd.component.annotations.Reference;
-import aQute.bnd.component.annotations.ReferenceCardinality;
-import aQute.bnd.component.annotations.ReferencePolicy;
-import aQute.bnd.component.annotations.ReferencePolicyOption;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import graphql.execution.preparsed.NoOpPreparsedDocumentProvider;
 import graphql.execution.preparsed.PreparsedDocumentProvider;
 import graphql.kickstart.servlet.config.DefaultGraphQLSchemaServletProvider;
@@ -38,6 +38,8 @@ import graphql.kickstart.execution.GraphQLRootObjectBuilder;
 import graphql.kickstart.servlet.core.GraphQLServletListener;
 import graphql.kickstart.servlet.input.GraphQLInvocationInputFactory;
 import graphql.kickstart.execution.instrumentation.NoOpInstrumentationProvider;
+import org.osgi.service.metatype.annotations.Designate;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -49,8 +51,9 @@ import java.util.concurrent.TimeUnit;
 
 @Component(
     service = {javax.servlet.http.HttpServlet.class, javax.servlet.Servlet.class},
-    property = {"alias=/graphql", "jmx.objectname=graphql.servlet:type=graphql"}
+    property = {"service.description=GraphQL HTTP Servlet"}
 )
+@Designate(ocd = OsgiGraphQLHttpServletConfiguration.class, factory = true)
 public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
 
   private final List<GraphQLQueryProvider> queryProviders = new ArrayList<>();

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/OsgiGraphQLHttpServletConfiguration.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/OsgiGraphQLHttpServletConfiguration.java
@@ -1,0 +1,14 @@
+package graphql.kickstart.servlet;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition(name = "GraphQL HTTP Servlet", description = "GraphQL HTTP Servlet Configuration")
+@interface OsgiGraphQLHttpServletConfiguration {
+
+    @AttributeDefinition(name = "alias", description = "Servlet alias")
+    String alias() default "/graphql";
+
+    @AttributeDefinition(name = "jmx.objectname", description = "JMX object name")
+    String jmx_objectname() default "graphql.servlet:type=graphql";
+}


### PR DESCRIPTION
This PR adds the ability to configure the servlet endpoint for the OSGi graphql servlet (default is `/graphql`)