### PR TITLE
writing content as bytes to avoid contentLength calculation problems

### DIFF
--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/BatchedQueryResponseWriter.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/BatchedQueryResponseWriter.java
@@ -33,8 +33,9 @@ class BatchedQueryResponseWriter implements QueryResponseWriter {
     responseBuilder.append(']');
 
     String responseContent = responseBuilder.toString();
-    response.setContentLength(responseContent.getBytes(StandardCharsets.UTF_8).length);
-    response.getWriter().write(responseContent);
+    byte[] contentBytes = responseContent.getBytes(StandardCharsets.UTF_8);
+    response.setContentLength(contentBytes.length);
+    response.getOutputStream().write(contentBytes);
   }
 
 }

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/SingleQueryResponseWriter.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/SingleQueryResponseWriter.java
@@ -21,8 +21,9 @@ class SingleQueryResponseWriter implements QueryResponseWriter {
     response.setStatus(HttpRequestHandler.STATUS_OK);
     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
     String responseContent = graphQLObjectMapper.serializeResultAsJson(result);
-    response.setContentLength(responseContent.getBytes(StandardCharsets.UTF_8).length);
-    response.getWriter().write(responseContent);
+    byte[] contentBytes = responseContent.getBytes(StandardCharsets.UTF_8);
+    response.setContentLength(contentBytes.length);
+    response.getOutputStream().write(contentBytes);
   }
 
 }

--- a/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/SingleQueryResponseWriterTest.groovy
+++ b/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/SingleQueryResponseWriterTest.groovy
@@ -7,8 +7,10 @@ import org.codehaus.groovy.runtime.StringBufferWriter
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import javax.servlet.ServletOutputStream
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+import java.nio.charset.StandardCharsets
 
 class SingleQueryResponseWriterTest extends Specification {
 
@@ -20,17 +22,15 @@ class SingleQueryResponseWriterTest extends Specification {
 
       def requestMock = Mock(HttpServletRequest)
       def responseMock = Mock(HttpServletResponse)
+      responseMock.getOutputStream() >> Mock(ServletOutputStream)
 
-      def responseContentBuffer = new StringBuffer()
-      responseMock.getWriter() >> new PrintWriter(new StringBufferWriter(responseContentBuffer))
       1 * responseMock.setContentLength(expectedContentLenght)
-      1 * responseMock.setCharacterEncoding("UTF-8")
+      1 * responseMock.setCharacterEncoding(StandardCharsets.UTF_8.name())
+      1 * responseMock.getOutputStream().write(expectedResponseContent.getBytes(StandardCharsets.UTF_8))
 
     expect:
       def writer = new SingleQueryResponseWriter(new ExecutionResultImpl(result, []), graphQLObjectMapperMock)
       writer.write(requestMock, responseMock)
-
-      responseContentBuffer.toString() == expectedResponseContent
 
     where:
       result                || expectedContentLenght | expectedResponseContent


### PR DESCRIPTION
The recent changes on `setContentLength` broke some spring-security functionality as spring-security recalculates `content-length` when `getWriter().write(String)` is called to check if the response is completed.
Therefore the session cookie will only be set after everything is over and the response was already sent back to the client.
Here's where this happens: [OnCommittedResponseWrapper.java](https://github.com/spring-projects/spring-security/blob/master/web/src/main/java/org/springframework/security/web/util/OnCommittedResponseWrapper.java#L222)

I think that using the same byte array used to set the `content-length` is the most secure way to avoid problems like this.

I also changed the test, but not sure if it was the correct approach.