### PR TITLE
Allow null values in DefaultExecutionStrategyProvider

### DIFF
--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/config/DefaultExecutionStrategyProvider.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/config/DefaultExecutionStrategyProvider.java
@@ -1,8 +1,6 @@
 package graphql.kickstart.execution.config;
 
-import graphql.execution.AsyncExecutionStrategy;
 import graphql.execution.ExecutionStrategy;
-import graphql.execution.SubscriptionExecutionStrategy;
 
 /**
  * @author Andrew Potter
@@ -18,19 +16,14 @@ public class DefaultExecutionStrategyProvider implements ExecutionStrategyProvid
   }
 
   public DefaultExecutionStrategyProvider(ExecutionStrategy executionStrategy) {
-    this(executionStrategy, null, null);
+    this(executionStrategy, executionStrategy, null);
   }
 
   public DefaultExecutionStrategyProvider(ExecutionStrategy queryExecutionStrategy,
       ExecutionStrategy mutationExecutionStrategy, ExecutionStrategy subscriptionExecutionStrategy) {
-    this.queryExecutionStrategy = defaultIfNull(queryExecutionStrategy, new AsyncExecutionStrategy());
-    this.mutationExecutionStrategy = defaultIfNull(mutationExecutionStrategy, this.queryExecutionStrategy);
-    this.subscriptionExecutionStrategy = defaultIfNull(subscriptionExecutionStrategy,
-        new SubscriptionExecutionStrategy());
-  }
-
-  private ExecutionStrategy defaultIfNull(ExecutionStrategy executionStrategy, ExecutionStrategy defaultStrategy) {
-    return executionStrategy != null ? executionStrategy : defaultStrategy;
+    this.queryExecutionStrategy = queryExecutionStrategy;
+    this.mutationExecutionStrategy = mutationExecutionStrategy;
+    this.subscriptionExecutionStrategy = subscriptionExecutionStrategy;
   }
 
   @Override

--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/config/GraphQLBuilder.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/config/GraphQLBuilder.java
@@ -1,6 +1,7 @@
 package graphql.kickstart.execution.config;
 
 import graphql.GraphQL;
+import graphql.execution.ExecutionStrategy;
 import graphql.execution.instrumentation.ChainedInstrumentation;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.SimpleInstrumentation;
@@ -49,11 +50,25 @@ public class GraphQLBuilder {
 
   public GraphQL build(GraphQLSchema schema, Supplier<Instrumentation> configuredInstrumentationSupplier) {
     ExecutionStrategyProvider executionStrategyProvider = executionStrategyProviderSupplier.get();
+    ExecutionStrategy queryExecutionStrategy = executionStrategyProvider.getQueryExecutionStrategy();
+    ExecutionStrategy mutationExecutionStrategy = executionStrategyProvider.getMutationExecutionStrategy();
+    ExecutionStrategy subscriptionExecutionStrategy = executionStrategyProvider.getSubscriptionExecutionStrategy();
+
     GraphQL.Builder builder = GraphQL.newGraphQL(schema)
-        .queryExecutionStrategy(executionStrategyProvider.getQueryExecutionStrategy())
-        .mutationExecutionStrategy(executionStrategyProvider.getMutationExecutionStrategy())
-        .subscriptionExecutionStrategy(executionStrategyProvider.getSubscriptionExecutionStrategy())
         .preparsedDocumentProvider(preparsedDocumentProviderSupplier.get());
+
+    if (queryExecutionStrategy != null) {
+      builder.queryExecutionStrategy(queryExecutionStrategy);
+    }
+
+    if (mutationExecutionStrategy != null) {
+      builder.mutationExecutionStrategy(mutationExecutionStrategy);
+    }
+
+    if (subscriptionExecutionStrategy != null) {
+      builder.subscriptionExecutionStrategy(subscriptionExecutionStrategy);
+    }
+
     Instrumentation instrumentation = configuredInstrumentationSupplier.get();
     builder.instrumentation(instrumentation);
     if (containsDispatchInstrumentation(instrumentation)) {


### PR DESCRIPTION
Allowing null values to be passed into DefaultExecutionStrategyProvider because graphql-java handles null values and uses defaults when null execution strategies are given, so there is no longer a need to have default values set in this library.

Here you will find the code that sets the default execution strategies in graphql-java: https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/GraphQL.java#L180-L182