### PR TITLE
Fix Subscription GraphQLRequest deserialization

### DIFF
--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/GraphQLSubscriptionMapper.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/GraphQLSubscriptionMapper.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import graphql.ExecutionResult;
 import graphql.kickstart.execution.GraphQLObjectMapper;
 import graphql.kickstart.execution.GraphQLRequest;
+import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -13,7 +15,12 @@ public class GraphQLSubscriptionMapper {
   private final GraphQLObjectMapper graphQLObjectMapper;
 
   public GraphQLRequest readGraphQLRequest(Object payload) {
-    return graphQLObjectMapper.getJacksonMapper().convertValue(payload, GraphQLRequest.class);
+    Objects.requireNonNull(payload, "Payload is required");
+    try {
+      return graphQLObjectMapper.readGraphQLRequest(payload.toString());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public ExecutionResult sanitizeErrors(ExecutionResult executionResult) {

--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/apollo/SubscriptionStartCommand.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/apollo/SubscriptionStartCommand.java
@@ -10,7 +10,6 @@ import graphql.kickstart.execution.subscriptions.GraphQLSubscriptionInvocationIn
 import graphql.kickstart.execution.subscriptions.GraphQLSubscriptionMapper;
 import graphql.kickstart.execution.subscriptions.SubscriptionSession;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +32,6 @@ class SubscriptionStartCommand implements SubscriptionCommand {
   }
 
   private CompletableFuture<ExecutionResult> executeAsync(Object payload, SubscriptionSession session) {
-    Objects.requireNonNull(payload, "Payload is required");
     GraphQLRequest graphQLRequest = mapper.readGraphQLRequest(payload);
 
     GraphQLSingleInvocationInput invocationInput = invocationInputFactory.create(graphQLRequest, session);

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/subscriptions/FallbackSubscriptionConsumer.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/subscriptions/FallbackSubscriptionConsumer.java
@@ -7,7 +7,6 @@ import graphql.kickstart.execution.input.GraphQLSingleInvocationInput;
 import graphql.kickstart.execution.subscriptions.GraphQLSubscriptionInvocationInputFactory;
 import graphql.kickstart.execution.subscriptions.GraphQLSubscriptionMapper;
 import graphql.kickstart.execution.subscriptions.SubscriptionSession;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -31,7 +30,6 @@ public class FallbackSubscriptionConsumer implements Consumer<String> {
   }
 
   private CompletableFuture<ExecutionResult> executeAsync(Object payload, SubscriptionSession session) {
-    Objects.requireNonNull(payload, "Payload is required");
     GraphQLRequest graphQLRequest = mapper.readGraphQLRequest(payload);
 
     GraphQLSingleInvocationInput invocationInput = invocationInputFactory.create(graphQLRequest, session);


### PR DESCRIPTION
Fixes the following error while subscription request deserialization:

```
2020-05-04 21:46:34:935 [https-jsse-nio-8079-exec-7] ERROR g.k.servlet.GraphQLWebsocketServlet - Error executing websocket query for session: 0
java.lang.IllegalArgumentException: Cannot construct instance of `graphql.kickstart.execution.GraphQLRequest` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('{"query":"subscription Logs { logs(eventId: \"87654\") { id } }"}')
 at [Source: UNKNOWN; line: -1, column: -1]
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:3938)
	at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:3869)
	at graphql.kickstart.execution.subscriptions.GraphQLSubscriptionMapper.readGraphQLRequest(GraphQLSubscriptionMapper.java:16)
	at java.lang.Thread.run(Thread.java:748) [22 skipped]
```

The error is seen in `9.1.0` as well as `9.2.0=SNAPSHOT`.


Probably related to:
https://github.com/graphql-java-kickstart/graphql-spring-boot/issues/366