### PR TITLE
Exclude overlap in dependency jars

### DIFF
--- a/graphql-java-servlet/bnd.bnd
+++ b/graphql-java-servlet/bnd.bnd
@@ -1,2 +1,2 @@
-Export-Package: graphql.kickstart.*
+Export-Package: graphql.kickstart.servlet.*
 Require-Capability: osgi.extender


### PR DESCRIPTION
@oliemansm 
Hello again, sry that i haven't been responsive lately after the last pull request.
Work got chaotic after the COVID situation.

I would like to present a more immediate fix to the underlying problem in this pull request.
The goal of this PR is not to make the project itself into modules, but rather to make it compatible with the module system.

Projects that are not made into modules can still be used by modules because they will normally be converted into automatic modules.

With graphql-java-servlet this is not possible (atleast not without heavy configuration) because of the overlapping classes/packages in the jar files that throw this process off.

https://github.com/graphql-java-kickstart/graphql-java-servlet/pull/244
I go into details here on how the problem looks like with the current jar files and how this bnd edit will resolve conflicting packages.

I originally wanted to take it one step further (making this project itself into modules), but for the short term we should focus on making it compatible.
