### PR TITLE
Support setting locale of execution input via context

### DIFF
--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/context/DefaultGraphQLContext.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/context/DefaultGraphQLContext.java
@@ -1,5 +1,6 @@
 package graphql.kickstart.execution.context;
 
+import java.util.Locale;
 import java.util.Optional;
 import javax.security.auth.Subject;
 import org.dataloader.DataLoaderRegistry;
@@ -13,13 +14,20 @@ public class DefaultGraphQLContext implements GraphQLContext {
 
   private final DataLoaderRegistry dataLoaderRegistry;
 
-  public DefaultGraphQLContext(DataLoaderRegistry dataLoaderRegistry, Subject subject) {
+  private final Locale locale;
+
+  public DefaultGraphQLContext(DataLoaderRegistry dataLoaderRegistry, Subject subject,Locale locale) {
     this.dataLoaderRegistry = dataLoaderRegistry;
     this.subject = subject;
+    this.locale = locale;
+  }
+
+  public DefaultGraphQLContext(DataLoaderRegistry dataLoaderRegistry, Subject subject) {
+    this(dataLoaderRegistry,subject,null);
   }
 
   public DefaultGraphQLContext() {
-    this(new DataLoaderRegistry(), null);
+    this(new DataLoaderRegistry(), null,null);
   }
 
   @Override
@@ -30,6 +38,11 @@ public class DefaultGraphQLContext implements GraphQLContext {
   @Override
   public Optional<DataLoaderRegistry> getDataLoaderRegistry() {
     return Optional.ofNullable(dataLoaderRegistry);
+  }
+
+  @Override
+  public Optional<Locale> getLocale() {
+    return Optional.ofNullable(locale);
   }
 
 }

--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/context/GraphQLContext.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/context/GraphQLContext.java
@@ -3,6 +3,7 @@ package graphql.kickstart.execution.context;
 import org.dataloader.DataLoaderRegistry;
 
 import javax.security.auth.Subject;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -19,4 +20,9 @@ public interface GraphQLContext {
      * @return the Dataloader registry to use for the execution.
      */
     Optional<DataLoaderRegistry> getDataLoaderRegistry();
+
+    /**
+     * @return the locale to use for the execution
+     */
+    Optional<Locale> getLocale();
 }

--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/input/GraphQLSingleInvocationInput.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/input/GraphQLSingleInvocationInput.java
@@ -46,6 +46,7 @@ public class GraphQLSingleInvocationInput implements GraphQLInvocationInput {
         .query(graphQLRequest.getQuery())
         .operationName(graphQLRequest.getOperationName())
         .context(context)
+        .locale(context.getLocale().orElse(null))
         .root(root)
         .variables(graphQLRequest.getVariables())
         .dataLoaderRegistry(context.getDataLoaderRegistry().orElse(new DataLoaderRegistry()))

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/context/DefaultGraphQLServletContext.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/context/DefaultGraphQLServletContext.java
@@ -8,6 +8,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -16,10 +17,14 @@ public class DefaultGraphQLServletContext extends DefaultGraphQLContext implemen
   private final HttpServletRequest httpServletRequest;
   private final HttpServletResponse httpServletResponse;
 
-  protected DefaultGraphQLServletContext(DataLoaderRegistry dataLoaderRegistry, Subject subject,
-      HttpServletRequest httpServletRequest,
-      HttpServletResponse httpServletResponse) {
-    super(dataLoaderRegistry, subject);
+  protected DefaultGraphQLServletContext(
+          DataLoaderRegistry dataLoaderRegistry,
+          Subject subject,
+          Locale locale,
+          HttpServletRequest httpServletRequest,
+          HttpServletResponse httpServletResponse
+  ) {
+    super(dataLoaderRegistry, subject,locale);
     this.httpServletRequest = httpServletRequest;
     this.httpServletResponse = httpServletResponse;
   }
@@ -70,6 +75,7 @@ public class DefaultGraphQLServletContext extends DefaultGraphQLContext implemen
     private HttpServletResponse httpServletResponse;
     private DataLoaderRegistry dataLoaderRegistry;
     private Subject subject;
+    private Locale locale;
 
     private Builder(DataLoaderRegistry dataLoaderRegistry, Subject subject) {
       this.dataLoaderRegistry = dataLoaderRegistry;
@@ -77,7 +83,7 @@ public class DefaultGraphQLServletContext extends DefaultGraphQLContext implemen
     }
 
     public DefaultGraphQLServletContext build() {
-      return new DefaultGraphQLServletContext(dataLoaderRegistry, subject, httpServletRequest, httpServletResponse);
+      return new DefaultGraphQLServletContext(dataLoaderRegistry, subject,locale, httpServletRequest, httpServletResponse);
     }
 
     public Builder with(HttpServletRequest httpServletRequest) {
@@ -92,6 +98,11 @@ public class DefaultGraphQLServletContext extends DefaultGraphQLContext implemen
 
     public Builder with(Subject subject) {
       this.subject = subject;
+      return this;
+    }
+
+    public Builder with(Locale locale) {
+      this.locale = locale;
       return this;
     }
 

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/context/DefaultGraphQLWebSocketContext.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/context/DefaultGraphQLWebSocketContext.java
@@ -6,14 +6,16 @@ import javax.websocket.Session;
 import javax.websocket.server.HandshakeRequest;
 import org.dataloader.DataLoaderRegistry;
 
+import java.util.Locale;
+
 public class DefaultGraphQLWebSocketContext extends DefaultGraphQLContext implements GraphQLWebSocketContext {
 
   private final Session session;
   private final HandshakeRequest handshakeRequest;
 
   private DefaultGraphQLWebSocketContext(DataLoaderRegistry dataLoaderRegistry, Subject subject,
-      Session session, HandshakeRequest handshakeRequest) {
-    super(dataLoaderRegistry, subject);
+                                         Locale locale, Session session, HandshakeRequest handshakeRequest) {
+    super(dataLoaderRegistry, subject,locale);
     this.session = session;
     this.handshakeRequest = handshakeRequest;
   }
@@ -42,6 +44,7 @@ public class DefaultGraphQLWebSocketContext extends DefaultGraphQLContext implem
     private HandshakeRequest handshakeRequest;
     private DataLoaderRegistry dataLoaderRegistry;
     private Subject subject;
+    private Locale locale;
 
     private Builder(DataLoaderRegistry dataLoaderRegistry, Subject subject) {
       this.dataLoaderRegistry = dataLoaderRegistry;
@@ -49,7 +52,7 @@ public class DefaultGraphQLWebSocketContext extends DefaultGraphQLContext implem
     }
 
     public DefaultGraphQLWebSocketContext build() {
-      return new DefaultGraphQLWebSocketContext(dataLoaderRegistry, subject, session, handshakeRequest);
+      return new DefaultGraphQLWebSocketContext(dataLoaderRegistry, subject, locale, session, handshakeRequest);
     }
 
     public Builder with(Session session) {
@@ -69,6 +72,11 @@ public class DefaultGraphQLWebSocketContext extends DefaultGraphQLContext implem
 
     public Builder with(Subject subject) {
       this.subject = subject;
+      return this;
+    }
+
+    public Builder with(Locale locale) {
+      this.locale = locale;
       return this;
     }
   }


### PR DESCRIPTION
Support setting of locale of `ExecutionInput` via `GraphQLContext` to allow e.g. i18n error messages