### PR TITLE
Allow Request Handler construct and calling for frameworks like Jerse…

### DIFF
--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/AbstractGraphQLHttpServlet.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/AbstractGraphQLHttpServlet.java
@@ -83,7 +83,7 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
   public void init() {
     if (configuration == null) {
       this.configuration = getConfiguration();
-      this.requestHandler = new HttpRequestHandlerImpl(configuration);
+      this.requestHandler = HttpRequestHandlerFactory.create(configuration);
     }
   }
 

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandler.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandler.java
@@ -3,7 +3,7 @@ package graphql.kickstart.servlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-interface HttpRequestHandler {
+public interface HttpRequestHandler {
 
   String APPLICATION_JSON_UTF8 = "application/json;charset=UTF-8";
   String APPLICATION_EVENT_STREAM_UTF8 = "text/event-stream;charset=UTF-8";

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandlerFactory.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandlerFactory.java
@@ -1,0 +1,14 @@
+package graphql.kickstart.servlet;
+
+public interface HttpRequestHandlerFactory {
+
+    /**
+     * Create a Request Handler instance for current servlet constructs
+     * and frameworks not needing explicit servlet construct (Jersey).
+     * @param configuration GraphQLConfiguration object
+     * @return HttpRequestHandler interface instance
+     */
+    static HttpRequestHandler create(GraphQLConfiguration configuration) {
+        return new HttpRequestHandlerImpl(configuration);
+    }
+}


### PR DESCRIPTION
To support frameworks like Jersey, where the servlet object is self managed typically and its resource class methods need to invoke kickstart for graphql query execution.