### PR TITLE
Added an ability to add headers before writing GraphQL response.

### DIFF
--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestInvokerImpl.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestInvokerImpl.java
@@ -91,7 +91,10 @@ public class HttpRequestInvokerImpl implements HttpRequestInvoker {
     return futureResult
         .thenApplyQueryResult()
         .thenAccept(
-            it -> writeResultResponse(futureResult.getInvocationInput(), it, request, response))
+            it -> {
+              listenerHandler.beforeFlush();
+              writeResultResponse(futureResult.getInvocationInput(), it, request, response);
+            })
         .thenAccept(it -> listenerHandler.onSuccess())
         .exceptionally(
             t ->

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/ListenerHandler.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/ListenerHandler.java
@@ -60,6 +60,10 @@ class ListenerHandler {
         });
   }
 
+  void beforeFlush() {
+    runCallbacks(it -> it.beforeFlush(request, response));
+  }
+
   void onSuccess() {
     runCallbacks(it -> it.onSuccess(request, response));
   }

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/core/GraphQLServletListener.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/core/GraphQLServletListener.java
@@ -6,17 +6,50 @@ import javax.servlet.http.HttpServletResponse;
 /** @author Andrew Potter */
 public interface GraphQLServletListener {
 
+  /**
+   * Called this method when the request started processing.
+   * @param request http request
+   * @param response http response
+   * @return request callback or {@literal null}
+   */
   default RequestCallback onRequest(HttpServletRequest request, HttpServletResponse response) {
     return null;
   }
 
+  /**
+   * The callback which used to add additional listeners for GraphQL request execution.
+   */
   interface RequestCallback {
 
+    /**
+     * Called right before the response will be written and flushed. Can be used for applying some
+     * changes to the response object, like adding response headers.
+     * @param request http request
+     * @param response http response
+     */
+    default void beforeFlush(HttpServletRequest request, HttpServletResponse response) {}
+
+    /**
+     * Called when GraphQL invoked successfully and the response was written already.
+     * @param request http request
+     * @param response http response
+     */
     default void onSuccess(HttpServletRequest request, HttpServletResponse response) {}
 
+    /**
+     * Called when GraphQL was failed and the response was written already.
+     * @param request http request
+     * @param response http response
+     */
     default void onError(
         HttpServletRequest request, HttpServletResponse response, Throwable throwable) {}
 
+    /**
+     * Called finally once on both success and failed GraphQL invocation. The response is also
+     * already written.
+     * @param request http request
+     * @param response http response
+     */
     default void onFinally(HttpServletRequest request, HttpServletResponse response) {}
   }
 }


### PR DESCRIPTION
Hello!

This PR adds a small but quite useful feature, it modifies the original `GraphQLServletListener` by adding an additional method `void beforeFlush(HttpServletRequest request, HttpServletResponse response)`, which will be called right before the response will be written and flushed. 

In our use-case it can be used to add headers like `API rate limit` or some temporal tokens generated after some GraphQL mutations were called together.