### PR TITLE
Shutdown executor and provide new endpoint constructor

### DIFF
--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/SubscriptionProtocolFactory.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/SubscriptionProtocolFactory.java
@@ -16,4 +16,8 @@ public abstract class SubscriptionProtocolFactory {
   }
 
   public abstract Consumer<String> createConsumer(SubscriptionSession session);
+
+  public void shutdown() {
+    // do nothing
+  }
 }

--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/apollo/ApolloSubscriptionConnectionListener.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/apollo/ApolloSubscriptionConnectionListener.java
@@ -20,4 +20,8 @@ public interface ApolloSubscriptionConnectionListener extends SubscriptionConnec
   default void onTerminate(SubscriptionSession session, OperationMessage message) {
     // do nothing
   }
+
+  default void shutdown() {
+    // do nothing
+  }
 }

--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/apollo/ApolloSubscriptionKeepAliveRunner.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/apollo/ApolloSubscriptionKeepAliveRunner.java
@@ -61,4 +61,8 @@ class ApolloSubscriptionKeepAliveRunner {
       future.cancel(true);
     }
   }
+
+  void shutdown() {
+    this.executor.shutdown();
+  }
 }

--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/apollo/KeepAliveSubscriptionConnectionListener.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/subscriptions/apollo/KeepAliveSubscriptionConnectionListener.java
@@ -6,7 +6,7 @@ import java.time.Duration;
 public class KeepAliveSubscriptionConnectionListener
     implements ApolloSubscriptionConnectionListener {
 
-  private final ApolloSubscriptionKeepAliveRunner keepAliveRunner;
+  protected final ApolloSubscriptionKeepAliveRunner keepAliveRunner;
 
   public KeepAliveSubscriptionConnectionListener() {
     this(Duration.ofSeconds(15));
@@ -35,4 +35,10 @@ public class KeepAliveSubscriptionConnectionListener
   public void onTerminate(SubscriptionSession session, OperationMessage message) {
     keepAliveRunner.abort(session);
   }
+
+  @Override
+  public void shutdown() {
+    keepAliveRunner.shutdown();
+  }
+
 }


### PR DESCRIPTION
Hi,

I ran into different issues when trying to use GraphQLWebsocketServlet within an OSGi container :
The first issue (which should also happen in any container) is about the executor started in ApolloSubscriptionKeepAliveRunner, which is never shut down, preventing the JVM to correctly quit. I've added shutdown callbacks in SubscriptionProtocolFactory / ApolloSubscriptionConnectionListener / ApolloSubscriptionKeepAliveRunner
Second issue is the GraphQLWebsocketServlet initialization - there's no way to pass explicit SubscriptionProtocolFactory, and prevent the creation of default instances, which was required in our case.
