### PR TITLE
Add listener for errors that occur in parsing `InvocationInput`

### DIFF
--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandlerImpl.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandlerImpl.java
@@ -36,7 +36,7 @@ class HttpRequestHandlerImpl implements HttpRequestHandler {
     }
 
     ListenerHandler listenerHandler =
-        ListenerHandler.start(request, response, configuration.getListeners());
+      ListenerHandler.start(request, response, configuration.getListeners());
 
     try {
       GraphQLInvocationInput invocationInput = parseInvocationInput(request, response);

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandlerImpl.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandlerImpl.java
@@ -1,6 +1,5 @@
 package graphql.kickstart.servlet;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import graphql.GraphQLException;
 import graphql.kickstart.execution.input.GraphQLInvocationInput;
 import java.io.IOException;

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandlerImpl.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandlerImpl.java
@@ -15,7 +15,7 @@ class HttpRequestHandlerImpl implements HttpRequestHandler {
   private final GraphQLConfiguration configuration;
   private final HttpRequestInvoker requestInvoker;
 
-  public HttpRequestHandlerImpl(GraphQLConfiguration configuration) {
+  HttpRequestHandlerImpl(GraphQLConfiguration configuration) {
     this(
         configuration,
         new HttpRequestInvokerImpl(
@@ -24,7 +24,7 @@ class HttpRequestHandlerImpl implements HttpRequestHandler {
             new QueryResponseWriterFactoryImpl()));
   }
 
-  public HttpRequestHandlerImpl(
+  HttpRequestHandlerImpl(
       GraphQLConfiguration configuration, HttpRequestInvoker requestInvoker) {
     this.configuration = configuration;
     this.requestInvoker = requestInvoker;
@@ -32,20 +32,22 @@ class HttpRequestHandlerImpl implements HttpRequestHandler {
 
   @Override
   public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    if (request.getCharacterEncoding() == null) {
+      request.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    }
+
+    ListenerHandler listenerHandler =
+        ListenerHandler.start(request, response, configuration.getListeners());
+
     try {
-      if (request.getCharacterEncoding() == null) {
-        request.setCharacterEncoding(StandardCharsets.UTF_8.name());
-      }
-      GraphQLInvocationInputParser invocationInputParser =
-          GraphQLInvocationInputParser.create(
-              request,
-              configuration.getInvocationInputFactory(),
-              configuration.getObjectMapper(),
-              configuration.getContextSetting());
-      GraphQLInvocationInput invocationInput =
-          invocationInputParser.  getGraphQLInvocationInput(request, response);
-      requestInvoker.execute(invocationInput, request, response);
-    } catch (GraphQLException | JsonProcessingException e) {
+      GraphQLInvocationInput invocationInput = parseInvocationInput(request, response);
+      requestInvoker.execute(invocationInput, request, response, listenerHandler);
+    } catch (InvocationInputParseException e) {
+      response.setStatus(STATUS_BAD_REQUEST);
+      log.info("Bad request: cannot parse http request", e);
+      listenerHandler.onParseError(e);
+      throw e;
+    } catch (GraphQLException e) {
       response.setStatus(STATUS_BAD_REQUEST);
       log.info("Bad request: cannot handle http request", e);
       throw e;
@@ -53,6 +55,22 @@ class HttpRequestHandlerImpl implements HttpRequestHandler {
       response.setStatus(STATUS_INTERNAL_SERVER_ERROR);
       log.error("Cannot handle http request", t);
       throw t;
+    }
+  }
+
+  private GraphQLInvocationInput parseInvocationInput(
+      HttpServletRequest request,
+      HttpServletResponse response) {
+    try {
+      GraphQLInvocationInputParser invocationInputParser =
+          GraphQLInvocationInputParser.create(
+              request,
+              configuration.getInvocationInputFactory(),
+              configuration.getObjectMapper(),
+              configuration.getContextSetting());
+      return invocationInputParser.getGraphQLInvocationInput(request, response);
+    } catch (Exception e) {
+      throw new InvocationInputParseException(e);
     }
   }
 }

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandlerImpl.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestHandlerImpl.java
@@ -62,11 +62,11 @@ class HttpRequestHandlerImpl implements HttpRequestHandler {
       HttpServletResponse response) {
     try {
       GraphQLInvocationInputParser invocationInputParser =
-          GraphQLInvocationInputParser.create(
-              request,
-              configuration.getInvocationInputFactory(),
-              configuration.getObjectMapper(),
-              configuration.getContextSetting());
+        GraphQLInvocationInputParser.create(
+          request,
+          configuration.getInvocationInputFactory(),
+          configuration.getObjectMapper(),
+          configuration.getContextSetting());
       return invocationInputParser.getGraphQLInvocationInput(request, response);
     } catch (Exception e) {
       throw new InvocationInputParseException(e);

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestInvoker.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestInvoker.java
@@ -9,5 +9,6 @@ public interface HttpRequestInvoker {
   void execute(
       GraphQLInvocationInput invocationInput,
       HttpServletRequest request,
-      HttpServletResponse response);
+      HttpServletResponse response,
+      ListenerHandler listenerHandler);
 }

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestInvokerImpl.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestInvokerImpl.java
@@ -39,9 +39,8 @@ public class HttpRequestInvokerImpl implements HttpRequestInvoker {
   public void execute(
       GraphQLInvocationInput invocationInput,
       HttpServletRequest request,
-      HttpServletResponse response) {
-    ListenerHandler listenerHandler =
-        ListenerHandler.start(request, response, configuration.getListeners());
+      HttpServletResponse response,
+      ListenerHandler listenerHandler) {
     if (request.isAsyncSupported()) {
       invokeAndHandleAsync(invocationInput, request, response, listenerHandler);
     } else {

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/InvocationInputParseException.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/InvocationInputParseException.java
@@ -1,0 +1,8 @@
+package graphql.kickstart.servlet;
+
+public class InvocationInputParseException extends RuntimeException {
+
+  public InvocationInputParseException(Throwable t) {
+    super("Request parsing failed", t);
+  }
+}

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/ListenerHandler.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/ListenerHandler.java
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-class ListenerHandler {
+public class ListenerHandler {
 
   private final List<RequestCallback> callbacks;
   private final HttpServletRequest request;
@@ -58,6 +58,10 @@ class ListenerHandler {
             log.error("Error running callback: {}", callback, t);
           }
         });
+  }
+
+  void onParseError(Throwable throwable) {
+    runCallbacks(it -> it.onParseError(request, response, throwable));
   }
 
   void beforeFlush() {

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/cache/CachingHttpRequestInvoker.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/cache/CachingHttpRequestInvoker.java
@@ -6,6 +6,7 @@ import graphql.kickstart.execution.input.GraphQLInvocationInput;
 import graphql.kickstart.servlet.GraphQLConfiguration;
 import graphql.kickstart.servlet.HttpRequestInvoker;
 import graphql.kickstart.servlet.HttpRequestInvokerImpl;
+import graphql.kickstart.servlet.ListenerHandler;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -36,11 +37,12 @@ public class CachingHttpRequestInvoker implements HttpRequestInvoker {
   public void execute(
       GraphQLInvocationInput invocationInput,
       HttpServletRequest request,
-      HttpServletResponse response) {
+      HttpServletResponse response,
+      ListenerHandler listenerHandler) {
     try {
       if (!cacheReader.responseFromCache(
           invocationInput, request, response, configuration.getResponseCacheManager())) {
-        requestInvoker.execute(invocationInput, request, response);
+        requestInvoker.execute(invocationInput, request, response, listenerHandler);
       }
     } catch (IOException e) {
       response.setStatus(STATUS_BAD_REQUEST);

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/core/GraphQLServletListener.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/core/GraphQLServletListener.java
@@ -22,6 +22,14 @@ public interface GraphQLServletListener {
   interface RequestCallback {
 
     /**
+     * Called when failed to parse InvocationInput and the response was not written.
+     * @param request http request
+     * @param response http response
+     */
+    default void onParseError(
+        HttpServletRequest request, HttpServletResponse response, Throwable throwable) {}
+
+    /**
      * Called right before the response will be written and flushed. Can be used for applying some
      * changes to the response object, like adding response headers.
      * @param request http request

--- a/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/AbstractGraphQLHttpServletSpec.groovy
+++ b/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/AbstractGraphQLHttpServletSpec.groovy
@@ -767,7 +767,7 @@ b
     servlet.doPost(request, response)
 
     then:
-    response.getStatus() == STATUS_ERROR
+    response.getStatus() == STATUS_BAD_REQUEST
     response.getContentLength() == 0
   }
 
@@ -1128,8 +1128,7 @@ b
     servlet.doGet(request, response)
 
     then:
-    noExceptionThrown()
-    response.getStatus() == STATUS_ERROR
+    response.getStatus() == STATUS_BAD_REQUEST
   }
 
   def "errors while data fetching are masked in the response"() {

--- a/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/AbstractGraphQLHttpServletSpec.groovy
+++ b/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/AbstractGraphQLHttpServletSpec.groovy
@@ -755,6 +755,22 @@ b
     getResponseContent().data.echoFiles == ["test", "test again"]
   }
 
+  def "errors while accessing file from the request"() {
+    setup:
+    request = Spy(MockHttpServletRequest)
+    request.setMethod("POST")
+    request.setContentType("multipart/form-data, boundary=test")
+    // See https://github.com/apache/tomcat/blob/main/java/org/apache/catalina/connector/Request.java#L2775...L2791
+    request.getParts() >> { throw new IllegalStateException() }
+
+    when:
+    servlet.doPost(request, response)
+
+    then:
+    response.getStatus() == STATUS_ERROR
+    response.getContentLength() == 0
+  }
+
   def "batched query over HTTP POST body returns data"() {
     setup:
     request.setContent('[{ "query": "query { echo(arg:\\"test\\") }" }, { "query": "query { echo(arg:\\"test\\") }" }]'.bytes)


### PR DESCRIPTION
As described in #417, we cannot handle the error when creating an`InvocationInput` with a servlet request.

- Change `ListenerHandler` creation location.
- Add `InvocationInputParseException` to isolate exception to parsing.
- Add `onParseError(...)` to `RequestCallback` interface and call it when `InvocationInputParseException` occurs.
- Fix related tests.

Closes #417 