### PR TITLE
Do not include "servlet-api" dependency

### DIFF
--- a/graphql-java-servlet/build.gradle
+++ b/graphql-java-servlet/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     api(project(':graphql-java-kickstart'))
 
     // Servlet
-    api 'javax.servlet:javax.servlet-api:4.0.1'
+    compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
     api 'javax.websocket:javax.websocket-api:1.1'
     implementation "org.slf4j:slf4j-api:$LIB_SLF4J_VER"
 


### PR DESCRIPTION
Hi @oliemansm !

The servlet API is typically provided by the servlet container. In Spring Boot applications that include the GraphQL servlet, the "api" dependency leads to duplicate classes, because the Tomcat embedded container already provides them.

I think it's safe to not include the dependency, because a Servlet is always used in a servlet container.

Best regards

Daniel