### PR TITLE
For non-async servlet wait until GraphQL async operation finished.

### DIFF
--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestInvokerImpl.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestInvokerImpl.java
@@ -20,6 +20,7 @@ import java.io.UncheckedIOException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.AsyncContext;
 import javax.servlet.http.HttpServletRequest;
@@ -105,7 +106,8 @@ public class HttpRequestInvokerImpl implements HttpRequestInvoker {
       ListenerHandler listenerHandler) {
     try {
       FutureExecutionResult futureResult = invoke(invocationInput, request, response);
-      handleInternal(futureResult, request, response, listenerHandler);
+      handleInternal(futureResult, request, response, listenerHandler)
+          .get(configuration.getAsyncTimeout(), TimeUnit.MILLISECONDS);
     } catch (GraphQLException e) {
       response.setStatus(STATUS_BAD_REQUEST);
       log.info("Bad request: cannot handle http request", e);


### PR DESCRIPTION
Hello!

We just upgraded to the latest version of https://github.com/graphql-java-kickstart/graphql-spring-boot/releases/tag/v13.0.0. And found that all of our tests failed.

The reason because we are not using a sync servlet, but our GraphQL partially uses common ForkJoinPool for fetching fields and the result is that the current HttpRequestInvokerImpl is not waiting for the result to be loaded.