### PR TITLE
Fixes for OSGi, remove automatic creation of executor for async requests

### DIFF
--- a/graphql-java-kickstart/bnd.bnd
+++ b/graphql-java-kickstart/bnd.bnd
@@ -1,4 +1,14 @@
 Export-Package: graphql.kickstart.*
 Import-Package: !lombok,\
-  graphql.*;version="[20.2,22)",\
+  graphql;version="[20.2,22)",\
+  graphql.execution;version="[20.2,22)",\
+  graphql.execution.instrumentation;version="[20.2,22)",\
+  graphql.execution.instrumentation.dataloader;version="[20.2,22)",\
+  graphql.execution.instrumentation.parameters;version="[20.2,22)",\
+  graphql.execution.preparsed;version="[20.2,22)",\
+  graphql.execution.reactive;version="[20.2,22)",\
+  graphql.introspection;version="[20.2,22)",\
+  graphql.language;version="[20.2,22)",\
+  graphql.parser;version="[20.2,22)",\
+  graphql.schema;version="[20.2,22)",\
   *

--- a/graphql-java-kickstart/bnd.bnd
+++ b/graphql-java-kickstart/bnd.bnd
@@ -1,2 +1,4 @@
 Export-Package: graphql.kickstart.*
-Import-Package: !lombok,*
+Import-Package: !lombok,\
+  graphql.*;version="[20.2,22)",\
+  *

--- a/graphql-java-servlet/bnd.bnd
+++ b/graphql-java-servlet/bnd.bnd
@@ -1,4 +1,13 @@
 Export-Package: graphql.kickstart.servlet.*
-Import-Package: !lombok,*
-Require-Capability: osgi.extender;
-  filter:="(&(osgi.extender=osgi.component)(version>=1.3)(!(version>=2.0)))"
+Import-Package: !lombok,\
+  graphql;version="[20.2,22)",\
+  graphql.execution.instrumentation;version="[20.2,22)",\
+  graphql.execution.preparsed;version="[20.2,22)",\
+  graphql.execution.reactive;version="[20.2,22)",\
+  graphql.schema;version="[20.2,22)",\
+  javax.servlet;version="[3.1,5)",\
+  javax.servlet.http;version="[3.1,5)",\
+  javax.websocket;version="[1.1,2)",\
+  javax.websocket.server;version="[1.1,2)",\
+  *
+Require-Capability: osgi.extender;filter:="(&(osgi.extender=osgi.component)(version>=1.3.0)(!(version>=2.0.0)))"

--- a/graphql-java-servlet/build.gradle
+++ b/graphql-java-servlet/build.gradle
@@ -16,16 +16,16 @@ dependencies {
     api(project(':graphql-java-kickstart'))
 
     // Servlet
-    compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
-    compileOnly 'javax.websocket:javax.websocket-api:1.1'
+    api 'javax.servlet:javax.servlet-api:3.1.0'
+    api 'javax.websocket:javax.websocket-api:1.1'
     implementation "org.slf4j:slf4j-api:$LIB_SLF4J_VER"
 
     // OSGi
     compileOnly 'org.osgi:org.osgi.core:6.0.0'
     compileOnly 'org.osgi:org.osgi.service.cm:1.6.1'
-    compileOnly 'org.osgi:org.osgi.service.component:1.5.1'
-    compileOnly 'org.osgi:org.osgi.service.component.annotations:1.5.1'
-    compileOnly 'org.osgi:org.osgi.service.metatype.annotations:1.4.1'
+    compileOnly 'org.osgi:org.osgi.service.component:1.3.0'
+    compileOnly 'org.osgi:org.osgi.service.component.annotations:1.3.0'
+    compileOnly 'org.osgi:org.osgi.service.metatype.annotations:1.3.0'
     compileOnly 'org.osgi:org.osgi.annotation:6.0.0'
 
     testImplementation 'io.github.graphql-java:graphql-java-annotations:9.1'

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/GraphQLHttpServlet.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/GraphQLHttpServlet.java
@@ -1,6 +1,7 @@
 package graphql.kickstart.servlet;
 
 import graphql.schema.GraphQLSchema;
+import java.util.concurrent.ThreadPoolExecutor;
 
 /** @author Michiel Oliemans */
 public abstract class GraphQLHttpServlet extends AbstractGraphQLHttpServlet {

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/GraphQLWebsocketServlet.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/GraphQLWebsocketServlet.java
@@ -265,7 +265,7 @@ public class GraphQLWebsocketServlet extends Endpoint {
     return isShutDown.get();
   }
 
-  private SubscriptionProtocolFactory getSubscriptionProtocolFactory(List<String> accept) {
+  public SubscriptionProtocolFactory getSubscriptionProtocolFactory(List<String> accept) {
     for (String protocol : accept) {
       for (SubscriptionProtocolFactory subscriptionProtocolFactory :
           subscriptionProtocolFactories) {

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestInvokerImpl.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/HttpRequestInvokerImpl.java
@@ -42,7 +42,7 @@ public class HttpRequestInvokerImpl implements HttpRequestInvoker {
       HttpServletRequest request,
       HttpServletResponse response,
       ListenerHandler listenerHandler) {
-    if (request.isAsyncSupported()) {
+    if (request.isAsyncSupported() && configuration.getAsyncExecutor() != null) {
       invokeAndHandleAsync(invocationInput, request, response, listenerHandler);
     } else {
       handle(invocationInput, request, response, listenerHandler);

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/OsgiGraphQLHttpServlet.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/OsgiGraphQLHttpServlet.java
@@ -15,6 +15,7 @@ import graphql.kickstart.servlet.core.DefaultGraphQLRootObjectBuilder;
 import graphql.kickstart.servlet.core.GraphQLServletListener;
 import graphql.kickstart.servlet.core.GraphQLServletRootObjectBuilder;
 import graphql.kickstart.servlet.osgi.GraphQLCodeRegistryProvider;
+import graphql.kickstart.servlet.osgi.GraphQLConfigurationProvider;
 import graphql.kickstart.servlet.osgi.GraphQLMutationProvider;
 import graphql.kickstart.servlet.osgi.GraphQLProvider;
 import graphql.kickstart.servlet.osgi.GraphQLQueryProvider;
@@ -40,6 +41,7 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
 
   public OsgiGraphQLHttpServlet() {
     schemaBuilder.updateSchema();
+    schemaBuilder.updateConfiguration();
   }
 
   @Activate
@@ -52,13 +54,21 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
     schemaBuilder.deactivate();
   }
 
+  public OsgiSchemaBuilder getSchemaBuilder() {
+    return schemaBuilder;
+  }
+
   @Override
   protected GraphQLConfiguration getConfiguration() {
-    return schemaBuilder.buildConfiguration();
+    return schemaBuilder.getConfiguration();
   }
 
   protected void updateSchema() {
     schemaBuilder.updateSchema();
+  }
+
+  protected void updateConfiguration() {
+    schemaBuilder.updateConfiguration();
   }
 
   @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
@@ -78,7 +88,11 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
     if (provider instanceof GraphQLCodeRegistryProvider) {
       schemaBuilder.setCodeRegistryProvider((GraphQLCodeRegistryProvider) provider);
     }
+    if (provider instanceof GraphQLConfigurationProvider) {
+      schemaBuilder.setConfigurationBuilderProvider((GraphQLConfigurationProvider) provider);
+    }
     updateSchema();
+    updateConfiguration();
   }
 
   public void unbindProvider(GraphQLProvider provider) {
@@ -96,6 +110,9 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
     }
     if (provider instanceof GraphQLCodeRegistryProvider) {
       schemaBuilder.setCodeRegistryProvider(() -> GraphQLCodeRegistry.newCodeRegistry().build());
+    }
+    if (provider instanceof GraphQLConfigurationProvider) {
+      schemaBuilder.setConfigurationBuilderProvider(GraphQLConfiguration.Builder::new);
     }
     updateSchema();
   }
@@ -147,28 +164,34 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
   @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
   public void bindServletListener(GraphQLServletListener listener) {
     schemaBuilder.add(listener);
+    updateConfiguration();
   }
 
   public void unbindServletListener(GraphQLServletListener listener) {
     schemaBuilder.remove(listener);
+    updateConfiguration();
   }
 
   @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
   public void setContextBuilder(GraphQLServletContextBuilder contextBuilder) {
     schemaBuilder.setContextBuilder(contextBuilder);
+    updateConfiguration();
   }
 
   public void unsetContextBuilder(GraphQLServletContextBuilder contextBuilder) {
     schemaBuilder.setContextBuilder(new DefaultGraphQLServletContextBuilder());
+    updateConfiguration();
   }
 
   @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
   public void setRootObjectBuilder(GraphQLServletRootObjectBuilder rootObjectBuilder) {
     schemaBuilder.setRootObjectBuilder(rootObjectBuilder);
+    updateConfiguration();
   }
 
   public void unsetRootObjectBuilder(GraphQLRootObjectBuilder rootObjectBuilder) {
     schemaBuilder.setRootObjectBuilder(new DefaultGraphQLRootObjectBuilder());
+    updateConfiguration();
   }
 
   @Reference(
@@ -177,10 +200,12 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
       policyOption = ReferencePolicyOption.GREEDY)
   public void setExecutionStrategyProvider(ExecutionStrategyProvider provider) {
     schemaBuilder.setExecutionStrategyProvider(provider);
+    updateConfiguration();
   }
 
   public void unsetExecutionStrategyProvider(ExecutionStrategyProvider provider) {
     schemaBuilder.setExecutionStrategyProvider(new DefaultExecutionStrategyProvider());
+    updateConfiguration();
   }
 
   @Reference(
@@ -189,10 +214,12 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
       policyOption = ReferencePolicyOption.GREEDY)
   public void setInstrumentationProvider(InstrumentationProvider provider) {
     schemaBuilder.setInstrumentationProvider(provider);
+    updateConfiguration();
   }
 
   public void unsetInstrumentationProvider(InstrumentationProvider provider) {
     schemaBuilder.setInstrumentationProvider(new NoOpInstrumentationProvider());
+    updateConfiguration();
   }
 
   @Reference(
@@ -201,10 +228,12 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
       policyOption = ReferencePolicyOption.GREEDY)
   public void setErrorHandler(GraphQLErrorHandler errorHandler) {
     schemaBuilder.setErrorHandler(errorHandler);
+    updateConfiguration();
   }
 
   public void unsetErrorHandler(GraphQLErrorHandler errorHandler) {
     schemaBuilder.setErrorHandler(new DefaultGraphQLErrorHandler());
+    updateConfiguration();
   }
 
   @Reference(
@@ -213,10 +242,12 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
       policyOption = ReferencePolicyOption.GREEDY)
   public void setPreparsedDocumentProvider(PreparsedDocumentProvider preparsedDocumentProvider) {
     schemaBuilder.setPreparsedDocumentProvider(preparsedDocumentProvider);
+    updateConfiguration();
   }
 
   public void unsetPreparsedDocumentProvider(PreparsedDocumentProvider preparsedDocumentProvider) {
     schemaBuilder.setPreparsedDocumentProvider(NoOpPreparsedDocumentProvider.INSTANCE);
+    updateConfiguration();
   }
 
   @Reference(
@@ -230,6 +261,20 @@ public class OsgiGraphQLHttpServlet extends AbstractGraphQLHttpServlet {
 
   public void unbindCodeRegistryProvider(GraphQLCodeRegistryProvider graphQLCodeRegistryProvider) {
     schemaBuilder.setCodeRegistryProvider(() -> GraphQLCodeRegistry.newCodeRegistry().build());
+    updateSchema();
+  }
+
+  @Reference(
+      cardinality = ReferenceCardinality.OPTIONAL,
+      policy = ReferencePolicy.DYNAMIC,
+      policyOption = ReferencePolicyOption.GREEDY)
+  public void bindConfigurationProvider(GraphQLConfigurationProvider graphQLConfigurationProvider) {
+    schemaBuilder.setConfigurationBuilderProvider(graphQLConfigurationProvider);
+    updateSchema();
+  }
+
+  public void unbindConfigurationProvider(GraphQLConfigurationProvider graphQLConfigurationProvider) {
+    schemaBuilder.setConfigurationBuilderProvider(GraphQLConfiguration.Builder::new);
     updateSchema();
   }
 

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/OsgiSchemaBuilder.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/OsgiSchemaBuilder.java
@@ -24,7 +24,7 @@ import graphql.kickstart.servlet.core.GraphQLServletListener;
 import graphql.kickstart.servlet.core.GraphQLServletRootObjectBuilder;
 import graphql.kickstart.servlet.input.GraphQLInvocationInputFactory;
 import graphql.kickstart.servlet.osgi.GraphQLCodeRegistryProvider;
-import graphql.kickstart.servlet.osgi.GraphQLFieldProvider;
+import graphql.kickstart.servlet.osgi.GraphQLConfigurationProvider;
 import graphql.kickstart.servlet.osgi.GraphQLMutationProvider;
 import graphql.kickstart.servlet.osgi.GraphQLQueryProvider;
 import graphql.kickstart.servlet.osgi.GraphQLSubscriptionProvider;
@@ -41,10 +41,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import lombok.Getter;
 import lombok.Setter;
 
 @Setter
-class OsgiSchemaBuilder {
+public class OsgiSchemaBuilder {
 
   private final List<GraphQLQueryProvider> queryProviders = new ArrayList<>();
   private final List<GraphQLMutationProvider> mutationProviders = new ArrayList<>();
@@ -62,23 +64,25 @@ class OsgiSchemaBuilder {
       NoOpPreparsedDocumentProvider.INSTANCE;
   private GraphQLCodeRegistryProvider codeRegistryProvider =
       () -> GraphQLCodeRegistry.newCodeRegistry().build();
+  private GraphQLConfigurationProvider configurationBuilderProvider = GraphQLConfiguration.Builder::new;
 
   private GraphQLSchemaServletProvider schemaProvider;
 
-  private ScheduledExecutorService executor;
+  private ScheduledExecutorService schemaExecutor;
   private ScheduledFuture<?> updateFuture;
   private int schemaUpdateDelay;
+  @Getter private GraphQLConfiguration configuration;
 
   void activate(int schemaUpdateDelay) {
     this.schemaUpdateDelay = schemaUpdateDelay;
     if (schemaUpdateDelay != 0) {
-      executor = Executors.newSingleThreadScheduledExecutor();
+      schemaExecutor = Executors.newSingleThreadScheduledExecutor();
     }
   }
 
   void deactivate() {
-    if (executor != null) {
-      executor.shutdown();
+    if (schemaExecutor != null) {
+      schemaExecutor.shutdown();
     }
   }
 
@@ -91,7 +95,7 @@ class OsgiSchemaBuilder {
       }
 
       updateFuture =
-          executor.schedule(this::doUpdateSchema, schemaUpdateDelay, TimeUnit.MILLISECONDS);
+          schemaExecutor.schedule(this::doUpdateSchema, schemaUpdateDelay, TimeUnit.MILLISECONDS);
     }
   }
 
@@ -136,25 +140,21 @@ class OsgiSchemaBuilder {
   }
 
   private GraphQLObjectType buildMutationType() {
-    return buildObjectType("Mutation", new ArrayList<>(mutationProviders));
+    return buildObjectType("Mutation", mutationProviders.stream().flatMap(s -> s.getMutations().stream()));
   }
 
   private GraphQLObjectType buildSubscriptionType() {
-    return buildObjectType("Subscription", new ArrayList<>(subscriptionProviders));
+    return buildObjectType("Subscription", subscriptionProviders.stream().flatMap(s -> s.getSubscriptions().stream()));
   }
 
-  private GraphQLObjectType buildObjectType(String name, List<GraphQLFieldProvider> providers) {
-    if (!providers.isEmpty()) {
-      final GraphQLObjectType.Builder typeBuilder =
-          newObject().name(name).description("Root " + name.toLowerCase() + " type");
+  private GraphQLObjectType buildObjectType(String name, Stream<GraphQLFieldDefinition> fields) {
+    final GraphQLObjectType.Builder typeBuilder =
+        newObject().name(name).description("Root " + name.toLowerCase() + " type");
 
-      for (GraphQLFieldProvider provider : providers) {
-        provider.getFields().forEach(typeBuilder::field);
-      }
+    fields.forEach(typeBuilder::field);
 
-      if (!typeBuilder.build().getFieldDefinitions().isEmpty()) {
-        return typeBuilder.build();
-      }
+    if (!typeBuilder.build().getFieldDefinitions().isEmpty()) {
+      return typeBuilder.build();
     }
     return null;
   }
@@ -195,8 +195,9 @@ class OsgiSchemaBuilder {
     return schemaProvider;
   }
 
-  GraphQLConfiguration buildConfiguration() {
-    return GraphQLConfiguration.with(buildInvocationInputFactory())
+  void updateConfiguration() {
+    configuration = configurationBuilderProvider.getConfigurationBuilder()
+        .with(buildInvocationInputFactory())
         .with(buildQueryInvoker())
         .with(buildObjectMapper())
         .with(listeners)

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLConfigurationProvider.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLConfigurationProvider.java
@@ -1,0 +1,8 @@
+package graphql.kickstart.servlet.osgi;
+
+import graphql.kickstart.servlet.GraphQLConfiguration;
+
+public interface GraphQLConfigurationProvider extends GraphQLProvider {
+
+  GraphQLConfiguration.Builder getConfigurationBuilder();
+}

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLFieldProvider.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLFieldProvider.java
@@ -1,9 +1,0 @@
-package graphql.kickstart.servlet.osgi;
-
-import graphql.schema.GraphQLFieldDefinition;
-import java.util.Collection;
-
-public interface GraphQLFieldProvider extends GraphQLProvider {
-
-  Collection<GraphQLFieldDefinition> getFields();
-}

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLMutationProvider.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLMutationProvider.java
@@ -3,7 +3,7 @@ package graphql.kickstart.servlet.osgi;
 import graphql.schema.GraphQLFieldDefinition;
 import java.util.Collection;
 
-public interface GraphQLMutationProvider {
+public interface GraphQLMutationProvider extends GraphQLProvider {
 
   Collection<GraphQLFieldDefinition> getMutations();
 }

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLMutationProvider.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLMutationProvider.java
@@ -3,11 +3,7 @@ package graphql.kickstart.servlet.osgi;
 import graphql.schema.GraphQLFieldDefinition;
 import java.util.Collection;
 
-public interface GraphQLMutationProvider extends GraphQLFieldProvider {
+public interface GraphQLMutationProvider {
 
   Collection<GraphQLFieldDefinition> getMutations();
-
-  default Collection<GraphQLFieldDefinition> getFields() {
-    return getMutations();
-  }
 }

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLSubscriptionProvider.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLSubscriptionProvider.java
@@ -3,11 +3,7 @@ package graphql.kickstart.servlet.osgi;
 import graphql.schema.GraphQLFieldDefinition;
 import java.util.Collection;
 
-public interface GraphQLSubscriptionProvider extends GraphQLFieldProvider {
+public interface GraphQLSubscriptionProvider {
 
   Collection<GraphQLFieldDefinition> getSubscriptions();
-
-  default Collection<GraphQLFieldDefinition> getFields() {
-    return getSubscriptions();
-  }
 }

--- a/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLSubscriptionProvider.java
+++ b/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/osgi/GraphQLSubscriptionProvider.java
@@ -3,7 +3,7 @@ package graphql.kickstart.servlet.osgi;
 import graphql.schema.GraphQLFieldDefinition;
 import java.util.Collection;
 
-public interface GraphQLSubscriptionProvider {
+public interface GraphQLSubscriptionProvider extends GraphQLProvider {
 
   Collection<GraphQLFieldDefinition> getSubscriptions();
 }

--- a/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/OsgiGraphQLHttpServletSpec.groovy
+++ b/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/OsgiGraphQLHttpServletSpec.groovy
@@ -70,7 +70,7 @@ class OsgiGraphQLHttpServletSpec extends Specification {
     servlet.getConfiguration().getInvocationInputFactory().getSchemaProvider().getReadOnlySchema().getQueryType().getFieldDefinitions().get(0).name == "_empty"
   }
 
-  static class TestMutationProvider implements GraphQLMutationProvider {
+  static class TestMutationProvider implements GraphQLMutationProvider, GraphQLProvider {
     @Override
     Collection<GraphQLFieldDefinition> getMutations() {
       return Collections.singletonList(newFieldDefinition().name("int").type(GraphQLInt).staticValue(1).build())
@@ -105,7 +105,7 @@ class OsgiGraphQLHttpServletSpec extends Specification {
     servlet.getConfiguration().getInvocationInputFactory().getSchemaProvider().getSchema().getMutationType() == null
   }
 
-  static class TestSubscriptionProvider implements GraphQLSubscriptionProvider {
+  static class TestSubscriptionProvider implements GraphQLSubscriptionProvider, GraphQLProvider {
     @Override
     Collection<GraphQLFieldDefinition> getSubscriptions() {
       return Collections.singletonList(newFieldDefinition().name("subscription").type(new GraphQLAnnotations().object(Subscription.class)).build())

--- a/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/OsgiGraphQLHttpServletSpec.groovy
+++ b/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/OsgiGraphQLHttpServletSpec.groovy
@@ -299,6 +299,7 @@ class OsgiGraphQLHttpServletSpec extends Specification {
 
     when:
     servlet.unsetContextBuilder(contextBuilder)
+    servlet.updateSchema()
     then:
     servlet.configuration.invocationInputFactory.create(request).executionInput.context instanceof DefaultGraphQLContext
   }
@@ -319,6 +320,7 @@ class OsgiGraphQLHttpServletSpec extends Specification {
 
     when:
     servlet.unsetRootObjectBuilder(rootObjectBuilder)
+    servlet.updateSchema()
     then:
     servlet.configuration.invocationInputFactory.create(request).executionInput.root != rootObject
   }
@@ -339,6 +341,7 @@ class OsgiGraphQLHttpServletSpec extends Specification {
 
     when:
     servlet.unsetExecutionStrategyProvider(executionStrategy)
+    servlet.updateSchema()
     def invocationInput2 = servlet.configuration.invocationInputFactory.create(request)
     servlet.configuration.graphQLInvoker.query(invocationInput2)
 

--- a/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/OsgiGraphQLHttpServletSpec.groovy
+++ b/graphql-java-servlet/src/test/groovy/graphql/kickstart/servlet/OsgiGraphQLHttpServletSpec.groovy
@@ -70,7 +70,7 @@ class OsgiGraphQLHttpServletSpec extends Specification {
     servlet.getConfiguration().getInvocationInputFactory().getSchemaProvider().getReadOnlySchema().getQueryType().getFieldDefinitions().get(0).name == "_empty"
   }
 
-  static class TestMutationProvider implements GraphQLMutationProvider, GraphQLProvider {
+  static class TestMutationProvider implements GraphQLMutationProvider {
     @Override
     Collection<GraphQLFieldDefinition> getMutations() {
       return Collections.singletonList(newFieldDefinition().name("int").type(GraphQLInt).staticValue(1).build())
@@ -105,7 +105,7 @@ class OsgiGraphQLHttpServletSpec extends Specification {
     servlet.getConfiguration().getInvocationInputFactory().getSchemaProvider().getSchema().getMutationType() == null
   }
 
-  static class TestSubscriptionProvider implements GraphQLSubscriptionProvider, GraphQLProvider {
+  static class TestSubscriptionProvider implements GraphQLSubscriptionProvider {
     @Override
     Collection<GraphQLFieldDefinition> getSubscriptions() {
       return Collections.singletonList(newFieldDefinition().name("subscription").type(new GraphQLAnnotations().object(Subscription.class)).build())


### PR DESCRIPTION
Hi,

Here's a PR with different fixes for OSGi, and a fix for https://github.com/graphql-java-kickstart/graphql-java-servlet/issues/537 . This has been done on the javax branch but should be portable on master. 

On OSGi side, I've changed version ranges so that it can be deployed on all compatible versions of servlet (3+) /websocket (1.1+) and graphql (the current code works well with graphql 20 and 21). Also updated the gradle dependencies accordingly.
I've changed GraphQLMutationProvider and GraphQLSubscriptionProvider that were both implementing the same `getFields` methods from GraphQLFieldsProvider (removed), preventing any provider to implement both interfaces. I'm not sure what was the reason to have a common getFields() method but the code seems more simple with the 2 different methods. Also exposed the `getSubscriptionProtocolFactory()` from websocket endpoint, as I need to be able to call it externally in my code ..

I've slightly changed the `GraphQLConfiguration.Builder` so that we can provide some base configuration from OSGi with a `GraphQLConfigurationProvider`. Also added some safeguard to prevent providing `invocationInputFactory` and `invocationInputFactoryBuilder`at the same time.

However, a big change in GraphqlConfiguration is the removal of the thread pool executor creation for async support, as explained in https://github.com/graphql-java-kickstart/graphql-java-servlet/issues/537 . In my opinion it cannot be created by the GraphQLConfiguration object or its builder, but should be created and managed by the servlet itself. The code creating a default thread pool (and destroying it) could be moved to `AbstractGraphQLHttpServlet` - but it should be possible to skip the creation of that default pool if we want to use our own executor. Tell me what do you think, I will update the PR if needed.
