### PR TITLE
chore(deps): replace cglib with byte-buddy

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/graphql-java-servlet/build.gradle
+++ b/graphql-java-servlet/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     // Unit testing
     testImplementation "org.apache.groovy:groovy-all:4.0.13"
     testImplementation "org.spockframework:spock-core:2.3-groovy-4.0"
-    testRuntimeOnly "cglib:cglib-nodep:3.3.0"
+    testRuntimeOnly "net.bytebuddy:byte-buddy:1.14.9"
     testRuntimeOnly "org.objenesis:objenesis:3.3"
     testImplementation "org.slf4j:slf4j-simple:$LIB_SLF4J_VER"
     testImplementation "org.springframework:spring-test:6.0.10"


### PR DESCRIPTION
- Replaced cglib with byte-buddy since cglib is deprecated
- Updated gradle version to 8.5

With these two bumps the build does not fail anymore