### PR TITLE
fix: remove Jdk8Module Jackson module registration

### DIFF
--- a/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/error/DefaultGraphQLServletObjectMapperConfigurer.java
+++ b/graphql-java-kickstart/src/main/java/graphql/kickstart/execution/error/DefaultGraphQLServletObjectMapperConfigurer.java
@@ -3,7 +3,6 @@ package graphql.kickstart.execution.error;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import graphql.kickstart.execution.config.GraphQLServletObjectMapperConfigurer;
 
 /** @author Andrew Potter */
@@ -12,9 +11,7 @@ public class DefaultGraphQLServletObjectMapperConfigurer
 
   @Override
   public void configure(ObjectMapper mapper) {
-    // default configuration for GraphQL Java Servlet
     mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-    mapper.registerModule(new Jdk8Module());
     mapper.setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS);
   }
 }


### PR DESCRIPTION
Since the project now runs on java >= 11 and uses the latest jackson version, it is no longer necessary to register this module because it is included in jackson-databind.

Refs: #570